### PR TITLE
Fixing external link to u-blox 8 specification

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Documents
    not actually relevant for the CDMA aspects, but has appendices on more
    precise orbit determinations.
  * [GPS](https://www.gps.gov/technical/icwg/IS-GPS-200K.pdf)
- * [U-blox 8 interface specification](https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29_Public.pdfhttps://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29_Public.pdf)
+ * [U-blox 8 interface specification](https://www.u-blox.com/sites/default/files/products/documents/u-blox8-M8_ReceiverDescrProtSpec_%28UBX-13003221%29_Public.pdf)
  * [U-blox 9 interface specification](https://www.u-blox.com/sites/default/files/u-blox_ZED-F9P_InterfaceDescription_%28UBX-18010854%29.pdf)
 
 


### PR DESCRIPTION
External link to u-blox 8 pdf was pasted two times in README file.