### PR TITLE
Proper serial setup

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -405,7 +405,7 @@ int initFD(const char* fname, bool doRTSCTS)
     }
 
     bzero(&newtio, sizeof(newtio));                                         
-    newtio.c_cflag = BAUDRATE | CS8 | CLOCAL | CREAD;             
+    newtio.c_cflag = CS8 | CLOCAL | CREAD;             
     if (doRTSCTS)
       newtio.c_cflag |= CRTSCTS;
     newtio.c_iflag = IGNPAR;                                                
@@ -417,8 +417,8 @@ int initFD(const char* fname, bool doRTSCTS)
     newtio.c_cc[VTIME]    = 0;   /* inter-character timer unused */         
     newtio.c_cc[VMIN]     = 5;   /* blocking read until 5 chars received */ 
     
-    tcflush(fd, TCIFLUSH);                                                  
-    if(tcsetattr(fd,TCSANOW, &newtio)) {
+    cfsetspeed(&newtio, BAUDRATE);
+    if(tcsetattr(fd, TCSAFLUSH, &newtio)) {
       perror("tcsetattr");
       exit(-1);
     }


### PR DESCRIPTION
I believe this code is better than what is currently used. Specifically, speed in not something stored in `c_cflag`, there is a function to set the speed field(s) in `struct termios`.

One of my test machines (OpenBSD/arvm7) still has some USB issues,  but that is likely hw related. Using this code on OpenBSD/amd64 seems to work properly.

The code is supposed to be portable, but I did not test that.