### PR TITLE
Add missing libncurses-dev dependency to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ To also run the webserver locally, intall libh2o-dev and run 'make'.
 To build everything, try:
 
 ```
-apt-get install protobuf-compiler libh2o-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev
+apt-get install protobuf-compiler libh2o-dev libcurl4-openssl-dev libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev libncurses-dev
 git clone https://github.com/ahupowerdns/galmon.git --recursive
 cd galmon
 make


### PR DESCRIPTION
`navdisplay.cc` includes `curses.h`, therefore `libncurses-dev` should be installed prior to compiling `galmon`.