### PR TITLE
Install libeigen3-dev during docker build.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN sed -i "s%http://archive.ubuntu.com/ubuntu/%${APT_URL}%" /etc/apt/sources.li
 # Update packages and install dependencies
 RUN apt-get update && apt-get -y upgrade && apt-get -y clean
 RUN apt-get install -y protobuf-compiler libh2o-dev libcurl4-openssl-dev \
-        libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev \
+        libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev libeigen3-dev \
 	make gcc g++ build-essential curl autoconf automake libfmt-dev libncurses5-dev \
     && apt-get -y clean
 


### PR DESCRIPTION
Since 9b92f69309f42d3b0beef99b105bda47cf478b27 builds require libeigen3-dev, this was updated in README.md but not in the Dockerfile.