### PR TITLE
Correct ublox port numbers, add description to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ configuration of your u-blox receiver so it emits the required frames for
 GPS and Galileo. If you have a u-blox timing receiver it will also enable
 the doppler frames.
 
+By default the ublox receiver module will be configured to use the USB port,
+if you want to use a different interface port on the ublox module then add
+the `--ubxport <id>` option using one of the following numeric IDs:
+
+   0 : DDC (aka. I2C)  
+   1 : UART[1]  
+   2 : UART2  
+   3 : USB (default)  
+   4 : SPI  
+
 To see what is going on, try:
 
 ```

--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -412,7 +412,7 @@ void enableUBXMessageOnPort(int fd, uint8_t ubxClass, uint8_t ubxType, uint8_t p
       basic_string<uint8_t> payload({ubxClass, ubxType, 0, 0, 0, 0, 0, 0});
       if(port > 6)
         throw std::runtime_error("Port number out of range (>6)");
-     payload[1+ port]=rate;
+     payload[2+ port]=rate;
 
      auto msg = buildUbxMessage(0x06, 0x01, payload);
       if(sendAndWaitForUBXAckNack(fd, 2, msg, 0x06, 0x01))
@@ -531,7 +531,7 @@ int main(int argc, char** argv)
 
   vector<string> destinations;
   string portName;
-  int ubxport=4;
+  int ubxport=3;
   int baudrate=115200;
 
   app.add_option("--destination,-d", destinations, "Send output to this IPv4/v6 address");
@@ -546,7 +546,7 @@ int main(int argc, char** argv)
   app.add_flag("--stdout", doSTDOUT, "Emit output to stdout");
   app.add_option("--port,-p", portName, "Device or file to read serial from")->required();
   app.add_option("--station", g_srcid, "Station id");
-  app.add_option("--ubxport,-u", ubxport, "UBX port to enable messages on (usb=4)");
+  app.add_option("--ubxport,-u", ubxport, "UBX port to enable messages on (usb=3)");
   app.add_option("--baud,-b", baudrate, "Baudrate for serial connection");
   app.add_flag("--keep-nmea,-k", doKeepNMEA, "Don't disable NMEA");
   


### PR DESCRIPTION
As discussed in #galileo.

The existing `usb=4` mapping appears to work for enabling messages due to another bug in the byte mapping, it does appear to not correctly disable the NMEA on the usb port.

This change both corrects the port numbers (as described below) and fixes the byte mapping bug in enabling the messages.

ublox M8 port numbers are described in "u-blox 8 / u-blox M8 Receiver Description - Manual" as:

  0 - I2C  
  1 - UART  
  2 - <reserved>  
  3 - USB  
  4 - SPI  

ublox ZED-F9P port numbers are described in "ZED-F9P - Integration Manual" as:

  0 - I2C  
  1 - UART1  
  2 - UART2  
  3 - USB  
  4 - SPI  

Tested on the UART interface, not tested on the USB interface.