### PR TITLE
Web standardization improvements

### DIFF
--- a/html/almanac.html
+++ b/html/almanac.html
@@ -17,8 +17,8 @@
   padding-bottom: 1px;
   font-family: monospace;
   }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
+  tr:nth-child(even) {background: #BFBFBF}
+  tr:nth-child(odd) {background: #E6E6E6}
   </style>
 </head>
 <body>

--- a/html/almanac.html
+++ b/html/almanac.html
@@ -1,22 +1,25 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
+<head>
+  <title>galmon.eu almanac</title>
+  <meta charset="utf-8">
+  <style>
 
-text {
-  font: 12px sans-serif;
-}
+  text {
+    font: 12px sans-serif;
+  }
 
 
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
-</style>
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
+  </style>
+</head>
 <body>
   Last update: <span id="freshness"></span><br/>
   Note: all distances are in kilometers!
@@ -26,7 +29,7 @@ tr:nth-child(odd) {background: #FFF}
     <span id="facts"></span>
   </p>
   <p>
-    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
+    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
   </p>
   <p>
     Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.

--- a/html/almanac.html
+++ b/html/almanac.html
@@ -11,11 +11,11 @@
 
 
   th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    font-family: monospace;
   }
   tr:nth-child(even) {background: #BFBFBF}
   tr:nth-child(odd) {background: #E6E6E6}
@@ -35,8 +35,8 @@
   <p>
     Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
   </p>
-    <script src="d3.v4.min.js"></script>
-    <script src="ext/moment-with-locales.js"></script>
-    <script src="almanac.js"></script>
+  <script src="d3.v4.min.js"></script>
+  <script src="ext/moment-with-locales.js"></script>
+  <script src="almanac.js"></script>
 </body>
 </html>

--- a/html/almanac.html
+++ b/html/almanac.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
   <title>galmon.eu almanac</title>
   <meta charset="utf-8">

--- a/html/geo/coverage.html
+++ b/html/geo/coverage.html
@@ -1,7 +1,8 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml">
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
     <title>galmon.eu geo</title>
+    <meta charset="utf-8">
     <link rel="stylesheet" type="text/css" href="geo.css">
 
     <script src="../d3.v4.min.js"></script>

--- a/html/geo/coverage.html
+++ b/html/geo/coverage.html
@@ -1,45 +1,44 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
-	<title>galmon.eu geo</title>
-	<link rel="stylesheet" type="text/css" href="geo.css">
+    <title>galmon.eu geo</title>
+    <link rel="stylesheet" type="text/css" href="geo.css">
 
-	<script src="../d3.v4.min.js"></script>
-	<script src="../ext/topojson.v1.min.js"></script>
-	<script src="../ext/d3-geo-projection.v2.min.js"></script> 
+    <script src="../d3.v4.min.js"></script>
+    <script src="../ext/topojson.v1.min.js"></script>
+    <script src="../ext/d3-geo-projection.v2.min.js"></script> 
 
 </head>
 <body>
-	<div id="galmongeo">
-		<div id="galmoninfo">
-		  This is a live map from the <a href="/">galmon.eu</a> project. This map can plot if a fix is possible ('Coverage') or if the positioning, horizontal or vertical precision will be bad (<a href="https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)">PDOP, HDOP, VDOP</a>). Red blocks indicate a problem even in perfect viewing conditions. Orange means a problem if there are obstructions below 10 degrees above of the horizon,
-                  yellow for less than 20 degrees ('urban canyon').
-                  <b>These <a href="https://github.com/ahupowerdns/galmon/blob/master/coverage.cc">calculations are very provisional</a> and might be wrong!</b>
-                  <center>
-                  <p>
-                    <input type="radio" name="kind" id="coverage" onclick="do_timer();" ><label for="coverage">Coverage</label>
-                      <input type="radio" name="kind" id="pdop" onclick="do_timer();" ><label for="pdop">PDOP &gt; 10 or no fix</label>
-                        <input type="radio" name="kind" id="hdop" onclick="do_timer();" checked><label for="hdop">HDOP &gt; 10 or no fix</label>
-                          <input type="radio" name="kind" id="vdop" onclick="do_timer();" ><label for="vdop">VDOP &gt; 10 or no fix</label>
-                                                  
+    <div id="galmongeo">
+        <div id="galmoninfo">
+          This is a live map from the <a href="/">galmon.eu</a> project. This map can plot if a fix is possible ('Coverage') or if the positioning, horizontal or vertical precision will be bad (<a href="https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)">PDOP, HDOP, VDOP</a>). Red blocks indicate a problem even in perfect viewing conditions. Orange means a problem if there are obstructions below 10 degrees above of the horizon, yellow for less than 20 degrees ('urban canyon').
+          <b>These <a href="https://github.com/ahupowerdns/galmon/blob/master/coverage.cc">calculations are very provisional</a> and might be wrong!</b>
+          <div class="centered">
+            <p>
+                <input type="radio" name="kind" id="coverage" onclick="do_timer();" ><label for="coverage">Coverage</label>
+                <input type="radio" name="kind" id="pdop" onclick="do_timer();" ><label for="pdop">PDOP &gt; 10 or no fix</label>
+                <input type="radio" name="kind" id="hdop" onclick="do_timer();" checked><label for="hdop">HDOP &gt; 10 or no fix</label>
+                <input type="radio" name="kind" id="vdop" onclick="do_timer();" ><label for="vdop">VDOP &gt; 10 or no fix</label>
+            </p>
+            <hr/>
+            <p>
+                <input type="checkbox"  id="GalE1" onclick="do_timer();" checked>  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
+                <input type="checkbox"  id="GPSL1CA" onclick="do_timer();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
+                <input type="checkbox"  id="Beidou" onclick="do_timer();">  <label for="Beidou">Beidou</label> &nbsp;&nbsp;
+            </p>
+          </div>
+        </div>
 
-                            <hr/>
-                            <input type="checkbox"  id="GalE1" onclick="do_timer();" checked>  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
-                              <input type="checkbox"  id="GPSL1CA" onclick="do_timer();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
-                                  <input type="checkbox"  id="Beidou" onclick="do_timer();">  <label for="Beidou">Beidou</label> &nbsp;&nbsp;
-</p>
-                      </center>
-		</div>
+        <div id="combined">
+            <svg id="svgworld"></svg>
+            <svg id="svggraticule"></svg>
+            <svg id="svgobservers"></svg>
+            <svg id="svgalmanac"></svg>
+        </div>
+    </div>
 
-		<div id="combined">
-			<svg id="svgworld"></svg>
-			<svg id="svggraticule"></svg>
-			<svg id="svgobservers"></svg>
-			<svg id="svgalmanac"></svg>
-		</div>
-	</div>
-
-	<script src="coverage.js"></script>
+    <script src="coverage.js"></script>
 </body>
 </html>
 

--- a/html/geo/coverage.html
+++ b/html/geo/coverage.html
@@ -1,45 +1,44 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-    <title>galmon.eu geo</title>
-    <meta charset="utf-8">
-    <link rel="stylesheet" type="text/css" href="geo.css">
+  <title>galmon.eu geo</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="geo.css">
 
-    <script src="../d3.v4.min.js"></script>
-    <script src="../ext/topojson.v1.min.js"></script>
-    <script src="../ext/d3-geo-projection.v2.min.js"></script> 
-
+  <script src="../d3.v4.min.js"></script>
+  <script src="../ext/topojson.v1.min.js"></script>
+  <script src="../ext/d3-geo-projection.v2.min.js"></script> 
 </head>
 <body>
-    <div id="galmongeo">
-        <div id="galmoninfo">
-          This is a live map from the <a href="/">galmon.eu</a> project. This map can plot if a fix is possible ('Coverage') or if the positioning, horizontal or vertical precision will be bad (<a href="https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)">PDOP, HDOP, VDOP</a>). Red blocks indicate a problem even in perfect viewing conditions. Orange means a problem if there are obstructions below 10 degrees above of the horizon, yellow for less than 20 degrees ('urban canyon').
-          <b>These <a href="https://github.com/ahupowerdns/galmon/blob/master/coverage.cc">calculations are very provisional</a> and might be wrong!</b>
-          <div class="centered">
-            <p>
-                <input type="radio" name="kind" id="coverage" onclick="do_timer();" ><label for="coverage">Coverage</label>
-                <input type="radio" name="kind" id="pdop" onclick="do_timer();" ><label for="pdop">PDOP &gt; 10 or no fix</label>
-                <input type="radio" name="kind" id="hdop" onclick="do_timer();" checked><label for="hdop">HDOP &gt; 10 or no fix</label>
-                <input type="radio" name="kind" id="vdop" onclick="do_timer();" ><label for="vdop">VDOP &gt; 10 or no fix</label>
-            </p>
-            <hr/>
-            <p>
-                <input type="checkbox"  id="GalE1" onclick="do_timer();" checked>  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
-                <input type="checkbox"  id="GPSL1CA" onclick="do_timer();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
-                <input type="checkbox"  id="Beidou" onclick="do_timer();">  <label for="Beidou">Beidou</label> &nbsp;&nbsp;
-            </p>
-          </div>
-        </div>
-
-        <div id="combined">
-            <svg id="svgworld"></svg>
-            <svg id="svggraticule"></svg>
-            <svg id="svgobservers"></svg>
-            <svg id="svgalmanac"></svg>
-        </div>
+  <div id="galmongeo">
+    <div id="galmoninfo">
+      This is a live map from the <a href="/">galmon.eu</a> project. This map can plot if a fix is possible ('Coverage') or if the positioning, horizontal or vertical precision will be bad (<a href="https://en.wikipedia.org/wiki/Dilution_of_precision_(navigation)">PDOP, HDOP, VDOP</a>). Red blocks indicate a problem even in perfect viewing conditions. Orange means a problem if there are obstructions below 10 degrees above of the horizon, yellow for less than 20 degrees ('urban canyon').
+      <b>These <a href="https://github.com/ahupowerdns/galmon/blob/master/coverage.cc">calculations are very provisional</a> and might be wrong!</b>
+      <div class="centered">
+        <p>
+          <input type="radio" name="kind" id="coverage" onclick="do_timer();" ><label for="coverage">Coverage</label>
+          <input type="radio" name="kind" id="pdop" onclick="do_timer();" ><label for="pdop">PDOP &gt; 10 or no fix</label>
+          <input type="radio" name="kind" id="hdop" onclick="do_timer();" checked><label for="hdop">HDOP &gt; 10 or no fix</label>
+          <input type="radio" name="kind" id="vdop" onclick="do_timer();" ><label for="vdop">VDOP &gt; 10 or no fix</label>
+        </p>
+        <hr/>
+        <p>
+          <input type="checkbox"  id="GalE1" onclick="do_timer();" checked>  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
+          <input type="checkbox"  id="GPSL1CA" onclick="do_timer();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
+          <input type="checkbox"  id="Beidou" onclick="do_timer();">  <label for="Beidou">Beidou</label> &nbsp;&nbsp;
+        </p>
+      </div>
     </div>
 
-    <script src="coverage.js"></script>
+    <div id="combined">
+        <svg id="svgworld"></svg>
+        <svg id="svggraticule"></svg>
+        <svg id="svgobservers"></svg>
+        <svg id="svgalmanac"></svg>
+    </div>
+  </div>
+
+  <script src="coverage.js"></script>
 </body>
 </html>
 

--- a/html/geo/geo.css
+++ b/html/geo/geo.css
@@ -266,3 +266,7 @@ path.merged {
   border: 1px gray solid;
   background: #eee;
 }
+.centered {
+  margin: auto 0px;
+  text-align: center;
+}

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html xmlns="http://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
 	<title>galmon.eu geo</title>
 	<link rel="stylesheet" type="text/css" href="geo.css">

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -1,76 +1,76 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
-	<meta charset="utf-8">
-	<title>galmon.eu geo</title>
-	<link rel="stylesheet" type="text/css" href="geo.css">
+  <meta charset="utf-8">
+  <title>galmon.eu geo</title>
+  <link rel="stylesheet" type="text/css" href="geo.css">
 
-	<script src='../ext/jquery.min.js'></script>
+  <script src='../ext/jquery.min.js'></script>
 
-	<script src="../d3.v4.min.js"></script>
-	<script src="../ext/topojson.v1.min.js"></script>
-	<script src="../ext/d3-geo-projection.v2.min.js"></script>
+  <script src="../d3.v4.min.js"></script>
+  <script src="../ext/topojson.v1.min.js"></script>
+  <script src="../ext/d3-geo-projection.v2.min.js"></script>
 </head>
 <body>
-	<div id="galmongeo">
-		<h1>galmon.eu geo</h1>
-		<div id="galmoninfo">
-		<span id="galmontext">
-			This is a live map from the <a href="/">galmon.eu</a> project
-		</span>
-		<span id="galmonchoice">
-			<label id="observer_map"  class="mybutton">Observer<input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-			&nbsp;|&nbsp;
-			<label id="coverage_map"  class="mybutton">Coverage<input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-			&nbsp;|&nbsp;
-			<label id="constilation1" class="mybutton">GPS     <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-			<label id="constilation2" class="mybutton">Galileo <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-			<label id="constilation3" class="mybutton">BeiDou  <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-			<!--
-			<label id="constilation4" class="mybutton">IMES    <input type="checkbox"                   disabled="disabled"><span class="checkmark"></span></label>
-			<label id="constilation5" class="mybutton">QZSS    <input type="checkbox"                   disabled="disabled"><span class="checkmark"></span></label>
-			-->
-			<label id="constilation6" class="mybutton">GLONASS <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
-		</span>
-		</div>
-		<div id="combined">
-			<svg id="svgworld"></svg>
-			<svg id="svggraticule"></svg>
-			<svg id="svgobservers"></svg>
-			<svg id="svgalmanac"></svg>
-			<span id="controls">
-				<label id="display_all" class="mybutton">Display All<input type="checkbox"><span class="checkmark"></span></label>
-				<br />
-				<!--
-				<label id="show_history" class="mybutton">History<input type="checkbox"><span class="checkmark"></span></label>
-				</p>
-				<label id="show_animate" class="mybutton">Animate<input type="checkbox"><span class="checkmark"></span></label>
-				</p>
-				-->
-				<label id="update_projection" class="mybutton">Projection<span class="checkmark"></span></label>
-			</span>
-			<div id="rotation">
-				<table class="rotatetable">
-				<tr>
-				<td></td>
-				<td><span id="rotate_north"  class="myrotate">&#8679;</span></td>
-				<td></td>
-				</tr>
-				<tr>
-				<td><span id="rotate_west"   class="myrotate">&#8678;</span></td>
-				<td><span id="rotate_center" class="myrotate">&#9711;</span></td>
-				<td><span id="rotate_east"   class="myrotate">&#8680;</span></td>
-				</tr>
-				<tr>
-				<td></td>
-				<td><span id="rotate_south"  class="myrotate">&#8681;</span></td>
-				<td></td>
-				</tr>
-				</table>
-			</div>
-		</div>
-	</div>
+  <div id="galmongeo">
+    <h1>galmon.eu geo</h1>
+    <div id="galmoninfo">
+    <span id="galmontext">
+      This is a live map from the <a href="/">galmon.eu</a> project
+    </span>
+    <span id="galmonchoice">
+      <label id="observer_map"  class="mybutton">Observer<input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+      &nbsp;|&nbsp;
+      <label id="coverage_map"  class="mybutton">Coverage<input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+      &nbsp;|&nbsp;
+      <label id="constilation1" class="mybutton">GPS     <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+      <label id="constilation2" class="mybutton">Galileo <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+      <label id="constilation3" class="mybutton">BeiDou  <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+      <!--
+      <label id="constilation4" class="mybutton">IMES    <input type="checkbox"                   disabled="disabled"><span class="checkmark"></span></label>
+      <label id="constilation5" class="mybutton">QZSS    <input type="checkbox"                   disabled="disabled"><span class="checkmark"></span></label>
+      -->
+      <label id="constilation6" class="mybutton">GLONASS <input type="checkbox" checked="checked"                    ><span class="checkmark"></span></label>
+    </span>
+    </div>
+    <div id="combined">
+      <svg id="svgworld"></svg>
+      <svg id="svggraticule"></svg>
+      <svg id="svgobservers"></svg>
+      <svg id="svgalmanac"></svg>
+      <span id="controls">
+        <label id="display_all" class="mybutton">Display All<input type="checkbox"><span class="checkmark"></span></label>
+        <br />
+        <!--
+        <label id="show_history" class="mybutton">History<input type="checkbox"><span class="checkmark"></span></label>
+        </p>
+        <label id="show_animate" class="mybutton">Animate<input type="checkbox"><span class="checkmark"></span></label>
+        </p>
+        -->
+        <label id="update_projection" class="mybutton">Projection<span class="checkmark"></span></label>
+      </span>
+      <div id="rotation">
+        <table class="rotatetable">
+          <tr>
+            <td></td>
+            <td><span id="rotate_north"  class="myrotate">&#8679;</span></td>
+            <td></td>
+          </tr>
+          <tr>
+            <td><span id="rotate_west"   class="myrotate">&#8678;</span></td>
+            <td><span id="rotate_center" class="myrotate">&#9711;</span></td>
+            <td><span id="rotate_east"   class="myrotate">&#8680;</span></td>
+          </tr>
+          <tr>
+            <td></td>
+            <td><span id="rotate_south"  class="myrotate">&#8681;</span></td>
+            <td></td>
+          </tr>
+        </table>
+      </div>
+    </div>
+  </div>
 
-	<script src="geo.js"></script>
+  <script src="geo.js"></script>
 </body>
 </html>

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml" lang="en">
 <head>
+	<meta charset="utf-8">
 	<title>galmon.eu geo</title>
 	<link rel="stylesheet" type="text/css" href="geo.css">
 
@@ -9,7 +10,6 @@
 	<script src="../d3.v4.min.js"></script>
 	<script src="../ext/topojson.v1.min.js"></script>
 	<script src="../ext/d3-geo-projection.v2.min.js"></script>
-
 </head>
 <body>
 	<div id="galmongeo">

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<!DOCTYPE html>
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>galmon.eu geo</title>

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -40,7 +40,7 @@
 			<svg id="svgalmanac"></svg>
 			<span id="controls">
 				<label id="display_all" class="mybutton">Display All<input type="checkbox"><span class="checkmark"></span></label>
-				</p>
+				<br />
 				<!--
 				<label id="show_history" class="mybutton">History<input type="checkbox"><span class="checkmark"></span></label>
 				</p>

--- a/html/geo/index.html
+++ b/html/geo/index.html
@@ -49,7 +49,7 @@
 				-->
 				<label id="update_projection" class="mybutton">Projection<span class="checkmark"></span></label>
 			</span>
-			<span id="rotation">
+			<div id="rotation">
 				<table class="rotatetable">
 				<tr>
 				<td></td>
@@ -67,7 +67,7 @@
 				<td></td>
 				</tr>
 				</table>
-			</span>
+			</div>
 		</div>
 	</div>
 

--- a/html/index.html
+++ b/html/index.html
@@ -1,137 +1,137 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>Galmon.eu - Galileo/GPS/GLONASS/BeiDou open source monitoring</title>
-    <style>
-    text {
-      font: 12px sans-serif;
-    }
+<head>
+  <meta charset="utf-8">
+  <title>galmon.eu</title>
+  <style>
+  text {
+    font: 12px sans-serif;
+  }
 
-    th, td {
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 1px;
-    padding-bottom: 1px;
-    font-family: monospace;
-    }
-    tr:nth-child(even) {background: #CCC}
-    tr:nth-child(odd) {background: #FFF}
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
 
-    label {
-       cursor: pointer;
-    }
-    input[type="checkbox"] {
-       cursor: pointer;
-    }
+  label {
+     cursor: pointer;
+  }
+  input[type="checkbox"] {
+     cursor: pointer;
+  }
 
 
-    .CellWithComment{
-      position:relative;
-    }
+  .CellWithComment{
+    position:relative;
+  }
 
-    .CellComment{
-      display:none;
-      position:absolute; 
-      z-index:100;
-      border:1px;
-      background-color:white;
-      border-style:solid;
-      border-width:1px;
-      border-color:red;
-      padding:3px;
-      color:red; 
-      top:20px; 
-      left:20px;
-    }
+  .CellComment{
+    display:none;
+    position:absolute; 
+    z-index:100;
+    border:1px;
+    background-color:white;
+    border-style:solid;
+    border-width:1px;
+    border-color:red;
+    padding:3px;
+    color:red; 
+    top:20px; 
+    left:20px;
+  }
 
-    .CellWithComment:hover span.CellComment{
-      display:block;
-    }
+  .CellWithComment:hover span.CellComment{
+    display:block;
+  }
 
-    .centered {
-      margin: auto 0px;
-      text-align: center;
-    }
+  .centered {
+    margin: auto 0px;
+    text-align: center;
+  }
 
-    #fields tr {
-      vertical-align:top;
-    }
+  #fields tr {
+    vertical-align:top;
+  }
 
-    </style>
-  </head>
-  <body>
-    Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
-    <div class="centered">
-      <hr/>
-      <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
-      <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
-    </div>
+  </style>
+</head>
+<body>
+  Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
+  <div class="centered">
     <hr/>
-    <table id="svs"></table>
-    <hr>
-    <p>
-      <span id="facts"></span>
+    <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
+  </div>
+  <hr/>
+  <table id="svs"></table>
+  <hr>
+  <p>
+    <span id="facts"></span>
+  </p>
+  Stale:<br/>
+  <table id="svsstale"></table>
+  <p>
+    This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States, Tonga, Brazil, Singapore, Austria, India and Uruguay.
+    It is very much a work in progress, and will not be available at all times. Extremely rough code is on
+    <a href="https://github.com/ahuPowerDNS/galmon">GitHub</a>.
+  </p>
+  <p>
+    Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
+  </p>
+  <p>
+  For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
+  <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
+  </p>
+  <p>
+    The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
     </p>
-    Stale:<br/>
-    <table id="svsstale"></table>
-    <p>
-      This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States, Tonga, Brazil, Singapore, Austria, India and Uruguay.
-      It is very much a work in progress, and will not be available at all times. Extremely rough code is on
-      <a href="https://github.com/ahuPowerDNS/galmon">GitHub</a>.
-    </p>
-    <p>
-      Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
-    </p>
-    <p>
-    For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
-    <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
-    </p>
-    <p>
-      The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
-      </p>
-    <table id="fields">
-      <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
-      <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
-      <tr><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
-      <tr><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
-      <tr><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
-      <tr><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
-      <tr><td>health</td><td>If a satellite considers itself healthy.</td></tr>
-      <tr><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
-      <tr><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
-      <tr><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
-      <tr><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
-      <tr><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
-      <tr><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
-      <tr><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
-      <tr><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
-      <tr><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
-      <tr><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
-    </table>
-    <p>
-      The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.
-    </p>
-    <p>
-      Official GLONASS status can be found on <a href="https://www.glonass-iac.ru/en/GLONASS/">this page</a> from the Russian Information and Analysis Center for Positioning, Navigation and Timing.
-    </p>
-    <p>
-      Sadly reduced status updates on GPS can be found on <a href="https://www.navcen.uscg.gov/?Do=constellationStatus">this page</a> from the US Department of Homeland Security.
-    </p>
-    <p>
-      Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
-    </p>
-    <p>
-      Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
-    </p>
-      <script src="d3.v4.min.js"></script>
-      <script src="ext/moment-with-locales.js"></script>
-    <script src="doalles.js"></script>
-  </body>
+  <table id="fields">
+    <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
+    <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
+    <tr><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
+    <tr><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
+    <tr><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
+    <tr><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
+    <tr><td>health</td><td>If a satellite considers itself healthy.</td></tr>
+    <tr><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
+    <tr><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
+    <tr><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
+    <tr><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
+    <tr><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
+    <tr><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
+    <tr><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
+    <tr><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
+    <tr><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
+    <tr><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
+  </table>
+  <p>
+    The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.
+  </p>
+  <p>
+    Official GLONASS status can be found on <a href="https://www.glonass-iac.ru/en/GLONASS/">this page</a> from the Russian Information and Analysis Center for Positioning, Navigation and Timing.
+  </p>
+  <p>
+    Sadly reduced status updates on GPS can be found on <a href="https://www.navcen.uscg.gov/?Do=constellationStatus">this page</a> from the US Department of Homeland Security.
+  </p>
+  <p>
+    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
+  </p>
+  <p>
+    Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
+  </p>
+    <script src="d3.v4.min.js"></script>
+    <script src="ext/moment-with-locales.js"></script>
+  <script src="doalles.js"></script>
+</body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -1,58 +1,60 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
+<head>
+  <meta charset="utf-8">
+  <title>Galmon.eu - Galileo/GPS/GLONASS/BeiDou open source monitoring</title>
+  <style>
+  text {
+    font: 12px sans-serif;
+  }
 
-text {
-  font: 12px sans-serif;
-}
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
 
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
-
-label {
-   cursor: pointer;
-}
-input[type="checkbox"] {
-   cursor: pointer;
-}
+  label {
+     cursor: pointer;
+  }
+  input[type="checkbox"] {
+     cursor: pointer;
+  }
 
 
-.CellWithComment{
-  position:relative;
-}
+  .CellWithComment{
+    position:relative;
+  }
 
-.CellComment{
-  display:none;
-  position:absolute; 
-  z-index:100;
-  border:1px;
-  background-color:white;
-  border-style:solid;
-  border-width:1px;
-  border-color:red;
-  padding:3px;
-  color:red; 
-  top:20px; 
-  left:20px;
-}
+  .CellComment{
+    display:none;
+    position:absolute; 
+    z-index:100;
+    border:1px;
+    background-color:white;
+    border-style:solid;
+    border-width:1px;
+    border-color:red;
+    padding:3px;
+    color:red; 
+    top:20px; 
+    left:20px;
+  }
 
-.CellWithComment:hover span.CellComment{
-  display:block;
-}
+  .CellWithComment:hover span.CellComment{
+    display:block;
+  }
 
-.centered {
-  margin: auto 0px;
-  text-align: center;
-}
+  .centered {
+    margin: auto 0px;
+    text-align: center;
+  }
 
-</style>
+  </style>
+</head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here!</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
   <div class="centered">

--- a/html/index.html
+++ b/html/index.html
@@ -73,37 +73,36 @@ input[type="checkbox"] {
     This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States, Tonga, Brazil, Singapore, Austria, India and Uruguay.
     It is very much a work in progress, and will not be available at all times. Extremely rough code is on
     <a href="https://github.com/ahuPowerDNS/galmon">GitHub</a>.
-
-    <p>
-      Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
-    </p>
-    <p>
-    For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
-    <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
-    </p>
-    <p>
-      The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
-      </p>
-    <table>
-      <tr valign="top"><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
-      <tr valign="top"><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
-      <tr valign="top"><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
-      <tr valign="top"><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
-      <tr valign="top"><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
-      <tr valign="top"><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
-      <tr valign="top"><td>health</td><td>If a satellite considers itself healthy.</td></tr>
-      <tr valign="top"><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
-      <tr valign="top"><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
-      <tr valign="top"><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
-      <tr valign="top"><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
-      <tr valign="top"><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
-      <tr valign="top"><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
-      <tr valign="top"><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
-      <tr valign="top"><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
-      <tr valign="top"><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
-      <tr valign="top"><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
-    </table>
   </p>
+  <p>
+    Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
+  </p>
+  <p>
+  For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
+  <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
+  </p>
+  <p>
+    The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
+    </p>
+  <table>
+    <tr valign="top"><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
+    <tr valign="top"><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
+    <tr valign="top"><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
+    <tr valign="top"><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
+    <tr valign="top"><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
+    <tr valign="top"><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
+    <tr valign="top"><td>health</td><td>If a satellite considers itself healthy.</td></tr>
+    <tr valign="top"><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
+    <tr valign="top"><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
+    <tr valign="top"><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
+    <tr valign="top"><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
+    <tr valign="top"><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
+    <tr valign="top"><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
+    <tr valign="top"><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
+    <tr valign="top"><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
+    <tr valign="top"><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
+    <tr valign="top"><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
+  </table>
   <p>
     The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.
   </p>

--- a/html/index.html
+++ b/html/index.html
@@ -1,136 +1,137 @@
 <!DOCTYPE html>
-<head>
-  <meta charset="utf-8">
-  <title>Galmon.eu - Galileo/GPS/GLONASS/BeiDou open source monitoring</title>
-  <style>
-  text {
-    font: 12px sans-serif;
-  }
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Galmon.eu - Galileo/GPS/GLONASS/BeiDou open source monitoring</title>
+    <style>
+    text {
+      font: 12px sans-serif;
+    }
 
-  th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
-  }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
+    th, td {
+    padding-left: 8px;
+    padding-right: 8px;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    font-family: monospace;
+    }
+    tr:nth-child(even) {background: #CCC}
+    tr:nth-child(odd) {background: #FFF}
 
-  label {
-     cursor: pointer;
-  }
-  input[type="checkbox"] {
-     cursor: pointer;
-  }
+    label {
+       cursor: pointer;
+    }
+    input[type="checkbox"] {
+       cursor: pointer;
+    }
 
 
-  .CellWithComment{
-    position:relative;
-  }
+    .CellWithComment{
+      position:relative;
+    }
 
-  .CellComment{
-    display:none;
-    position:absolute; 
-    z-index:100;
-    border:1px;
-    background-color:white;
-    border-style:solid;
-    border-width:1px;
-    border-color:red;
-    padding:3px;
-    color:red; 
-    top:20px; 
-    left:20px;
-  }
+    .CellComment{
+      display:none;
+      position:absolute; 
+      z-index:100;
+      border:1px;
+      background-color:white;
+      border-style:solid;
+      border-width:1px;
+      border-color:red;
+      padding:3px;
+      color:red; 
+      top:20px; 
+      left:20px;
+    }
 
-  .CellWithComment:hover span.CellComment{
-    display:block;
-  }
+    .CellWithComment:hover span.CellComment{
+      display:block;
+    }
 
-  .centered {
-    margin: auto 0px;
-    text-align: center;
-  }
+    .centered {
+      margin: auto 0px;
+      text-align: center;
+    }
 
-  #fields tr {
-    vertical-align:top;
-  }
+    #fields tr {
+      vertical-align:top;
+    }
 
-  </style>
-</head>
-<body>
-  Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here!</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
-  <div class="centered">
+    </style>
+  </head>
+  <body>
+    Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here!</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
+    <div class="centered">
+      <hr/>
+      <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
+      <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
+    </div>
     <hr/>
-    <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
-    <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
-  </div>
-  <hr/>
-  <table id="svs"></table>
-  <hr>
-  <p>
-    <span id="facts"></span>
-  </p>
-  Stale:<br/>
-  <table id="svsstale"></table>
-  <p>
-    This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States, Tonga, Brazil, Singapore, Austria, India and Uruguay.
-    It is very much a work in progress, and will not be available at all times. Extremely rough code is on
-    <a href="https://github.com/ahuPowerDNS/galmon">GitHub</a>.
-  </p>
-  <p>
-    Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
-  </p>
-  <p>
-  For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
-  <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
-  </p>
-  <p>
-    The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
+    <table id="svs"></table>
+    <hr>
+    <p>
+      <span id="facts"></span>
     </p>
-  <table id="fields">
-    <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
-    <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
-    <tr><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
-    <tr><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
-    <tr><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
-    <tr><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
-    <tr><td>health</td><td>If a satellite considers itself healthy.</td></tr>
-    <tr><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
-    <tr><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
-    <tr><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
-    <tr><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
-    <tr><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
-    <tr><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
-    <tr><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
-    <tr><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
-    <tr><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
-    <tr><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
-  </table>
-  <p>
-    The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.
-  </p>
-  <p>
-    Official GLONASS status can be found on <a href="https://www.glonass-iac.ru/en/GLONASS/">this page</a> from the Russian Information and Analysis Center for Positioning, Navigation and Timing.
-  </p>
-  <p>
-    Sadly reduced status updates on GPS can be found on <a href="https://www.navcen.uscg.gov/?Do=constellationStatus">this page</a> from the US Department of Homeland Security.
-  </p>
-  <p>
-    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
-  </p>
-  <p>
-    Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
-  </p>
-    <script src="d3.v4.min.js"></script>
-    <script src="ext/moment-with-locales.js"></script>
-  <script src="doalles.js"></script>
-</body>
+    Stale:<br/>
+    <table id="svsstale"></table>
+    <p>
+      This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States, Tonga, Brazil, Singapore, Austria, India and Uruguay.
+      It is very much a work in progress, and will not be available at all times. Extremely rough code is on
+      <a href="https://github.com/ahuPowerDNS/galmon">GitHub</a>.
+    </p>
+    <p>
+      Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
+    </p>
+    <p>
+    For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
+    <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
+    </p>
+    <p>
+      The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
+      </p>
+    <table id="fields">
+      <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
+      <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
+      <tr><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
+      <tr><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
+      <tr><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
+      <tr><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
+      <tr><td>health</td><td>If a satellite considers itself healthy.</td></tr>
+      <tr><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
+      <tr><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
+      <tr><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
+      <tr><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
+      <tr><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
+      <tr><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
+      <tr><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
+      <tr><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
+      <tr><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
+      <tr><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
+    </table>
+    <p>
+      The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.
+    </p>
+    <p>
+      Official GLONASS status can be found on <a href="https://www.glonass-iac.ru/en/GLONASS/">this page</a> from the Russian Information and Analysis Center for Positioning, Navigation and Timing.
+    </p>
+    <p>
+      Sadly reduced status updates on GPS can be found on <a href="https://www.navcen.uscg.gov/?Do=constellationStatus">this page</a> from the US Department of Homeland Security.
+    </p>
+    <p>
+      Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
+    </p>
+    <p>
+      Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
+    </p>
+      <script src="d3.v4.min.js"></script>
+      <script src="ext/moment-with-locales.js"></script>
+    <script src="doalles.js"></script>
+  </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -113,7 +113,7 @@ input[type="checkbox"] {
     Sadly reduced status updates on GPS can be found on <a href="https://www.navcen.uscg.gov/?Do=constellationStatus">this page</a> from the US Department of Homeland Security.
   </p>
   <p>
-    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
+    Information on the status of BeiDou can be found on <a href="http://www.csno-tarc.cn/system/constellation&amp;ce=english">this page</a> from the Chinese Test and Assessment Research Center of China Satellite Navigation Office.
   </p>
   <p>
     Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.

--- a/html/index.html
+++ b/html/index.html
@@ -47,20 +47,25 @@ input[type="checkbox"] {
   display:block;
 }
 
+.centered {
+  margin: auto 0px;
+  text-align: center;
+}
+
 </style>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here!</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
-  <center>
+  <div class="centered">
     <hr/>
-  <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
-  <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
-  </center>
+    <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GalE5b" onclick="updateSats();">  <label for="GalE5b">Galileo E5b</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="BeiDouB1I" onclick="updateSats();">  <label for="BeiDouB1I">BeiDou B1I</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="BeiDouB2I" onclick="updateSats();">  <label for="BeiDouB2I">BeiDou B2I</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GlonassL1" onclick="updateSats();">  <label for="GlonassL1">Glonass L1</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GlonassL2" onclick="updateSats();">  <label for="GlonassL2">Glonass L2</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GPSL1CA" onclick="updateSats();">  <label for="GPSL1CA">GPS L1C/A</label> &nbsp;&nbsp;
+    <input type="checkbox"  id="GPSL2C" onclick="updateSats();">  <label for="GPSL2C">GPS L2C</label>
+  </div>
   <hr/>
   <table id="svs"></table>
   <hr>

--- a/html/index.html
+++ b/html/index.html
@@ -90,12 +90,12 @@
     Some technical detail behind this setup can be found in <a href="https://berthub.eu/articles/posts/galileo-notes/">this post</a>.
   </p>
   <p>
-  For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
-  <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
+    For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
+    <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
   </p>
   <p>
     The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
-    </p>
+  </p>
   <table id="fields">
     <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
     <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
@@ -130,8 +130,8 @@
   <p>
     Feedback is very welcome on bert@hubertnet.nl or <a href="https://twitter.com/PowerDNS_Bert">@PowerDNS_Bert</a>.
   </p>
-    <script src="d3.v4.min.js"></script>
-    <script src="ext/moment-with-locales.js"></script>
+  <script src="d3.v4.min.js"></script>
+  <script src="ext/moment-with-locales.js"></script>
   <script src="doalles.js"></script>
 </body>
 </html>

--- a/html/index.html
+++ b/html/index.html
@@ -61,7 +61,7 @@
     </style>
   </head>
   <body>
-    Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here!</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
+    Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>
     <div class="centered">
       <hr/>
       <input type="checkbox"  id="GalE1" onclick="updateSats();">  <label for="GalE1">Galileo E1</label> &nbsp;&nbsp;

--- a/html/index.html
+++ b/html/index.html
@@ -15,8 +15,8 @@
   padding-bottom: 1px;
   font-family: monospace;
   }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
+  tr:nth-child(even) {background: #BFBFBF}
+  tr:nth-child(odd) {background: #E6E6E6}
 
   label {
      cursor: pointer;

--- a/html/index.html
+++ b/html/index.html
@@ -53,6 +53,10 @@
     text-align: center;
   }
 
+  #fields tr {
+    vertical-align:top;
+  }
+
   </style>
 </head>
 <body>
@@ -91,24 +95,24 @@
   <p>
     The meaning of the fields is explained in <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">this document</a> and can be summarised as follows:
     </p>
-  <table>
-    <tr valign="top"><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
-    <tr valign="top"><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
-    <tr valign="top"><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
-    <tr valign="top"><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
-    <tr valign="top"><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
-    <tr valign="top"><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
-    <tr valign="top"><td>health</td><td>If a satellite considers itself healthy.</td></tr>
-    <tr valign="top"><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
-    <tr valign="top"><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
-    <tr valign="top"><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
-    <tr valign="top"><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
-    <tr valign="top"><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
-    <tr valign="top"><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
-    <tr valign="top"><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
-    <tr valign="top"><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
-    <tr valign="top"><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
-    <tr valign="top"><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
+  <table id="fields">
+    <tr><td>sv</td><td>Satellite Vehicle, an identifier for a Galileo satellite. Not the actual name of the satellite, other satellites could take over this number in case of failures</td></tr>
+    <tr><td>iod</td><td>Issue of Data. Satellites periodically get sent updates on their orbit &amp; other details, each update has a new IOD number. It is coincidence that all SVs currently receive the same IOD numbers, this is by no means guaranteed. Currently however, if an SV has a lower IOD, it has not received new updates recently.</td></tr>
+    <tr><td>eph‑age‑m</td><td>Age of ephemeris in minutes. Denotes how old the current set of orbit data is. Could be very old if SV is out of sight (see below). An acceptable limit is 4 hours (240 minutes).</td></tr>
+    <tr><td>latest-disco</td><td>"jump" of the orbit prediction at the latest ephemeris change. Centimeters are good.</td></tr>
+    <tr><td>time-disco</td><td>"jump" of the atomic clock at the latest ephemeris change.</td></tr>
+    <tr><td>sisa</td><td>Signal In Space Accuracy, how well the position of an SV is known.</td></tr>
+    <tr><td>health</td><td>If a satellite considers itself healthy.</td></tr>
+    <tr><td>delta-UTC</td><td>Offset of the GNSS Time to UTC, plus trend</td></tr>
+    <tr><td>delta-GPS</td><td>Offset of the GNSS Time to GPS, plus trend</td></tr>
+    <tr><td>alma-dist</td><td>Distance between precise satellite position and almanac summary position</td></tr>
+    <tr><td>tle-dist</td><td>Distance between precise satellite position and TLE position</td></tr>
+    <tr><td>best-tle</td><td>From TLE database, closest satellite to reported position</td></tr>
+    <tr><td>prres</td><td>Pseudorange residual: measure of how far away the satellite <b>appears</b> to be from where it should be, according to a receiver. Meters.</td></tr>
+    <tr><td>delta-Hz</td><td>Difference between calculated (expected) Doppler shift and measured Doppler shift. Measure of orbit correctness. Hz.</td></tr>   
+    <tr><td>elev</td><td>Elevation of an SV over or under my horizon (90 is straight up), calculated by this website</td></tr>
+    <tr><td>db</td><td>A measure of signal to noise ratio (40+ is good)</td></tr>
+    <tr><td>last‑seen‑s</td><td>Time since we've last received from this SV.</td></tr>
   </table>
   <p>
     The official Galileo constellation status can be found on the <a href="https://www.gsc-europa.eu/system-status/Constellation-Information">European GNSS Service Centre page</a>, which also lists "NAGUs", <a href="https://www.gsc-europa.eu/system-status/user-notifications">notifications about outages or changes</a>.

--- a/html/observer.html
+++ b/html/observer.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
   <title>galmon.eu observer</title>
   <meta charset="utf-8">
@@ -29,8 +30,8 @@
 </head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
-<table><tr><td valign="top">
-  <table id="galileo"></table></td><td valign="top">
+<table><tr><td style="vertical-align:top">
+  <table id="galileo"></table></td><td style="vertical-align:top">
 
   <div class="Orbits">
     <div class="centered">

--- a/html/observer.html
+++ b/html/observer.html
@@ -1,33 +1,41 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
+<head>
+  <title>galmon.eu observer</title>
+  <meta charset="utf-8">
+  <style>
 
-text {
-  font: 12px sans-serif;
-}
+  text {
+    font: 12px sans-serif;
+  }
 
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
 
-.Orbits{margin-top:3em;margin-bottom:1em}.Orbits .Variables{display:inline-block;vertical-align:top;width:28em;height:44em;overflow:auto;position:relative}.Orbits .Variables table{font-family:'Roboto Mono',monospace;color:#000;border-spacing:.5em;display:block;position:absolute;left:50%;transform:translateX(-50%)}.Orbits .Variables table tr{text-align:center}.Orbits .Variables table td{font-size:.85em}.Orbits .Drawing{display:inline-block;vertical-align:top;margin-top:.5em;width:44em;height:44em}.Orbits .Drawing .sats-label{font-size:12px;fill:#454545;font-weight:bold;stroke:transparent}.Orbits .Drawing .satellite circle{stroke-width:2px}.Orbits .Drawing svg{font-family:sans-serif;font-size:10px;text-anchor:middle;fill:none;stroke:#000;width:100%;height:100%}
+  .Orbits{margin-top:3em;margin-bottom:1em}.Orbits .Variables{display:inline-block;vertical-align:top;width:28em;height:44em;overflow:auto;position:relative}.Orbits .Variables table{font-family:'Roboto Mono',monospace;color:#000;border-spacing:.5em;display:block;position:absolute;left:50%;transform:translateX(-50%)}.Orbits .Variables table tr{text-align:center}.Orbits .Variables table td{font-size:.85em}.Orbits .Drawing{display:inline-block;vertical-align:top;margin-top:.5em;width:44em;height:44em}.Orbits .Drawing .sats-label{font-size:12px;fill:#454545;font-weight:bold;stroke:transparent}.Orbits .Drawing .satellite circle{stroke-width:2px}.Orbits .Drawing svg{font-family:sans-serif;font-size:10px;text-anchor:middle;fill:none;stroke:#000;width:100%;height:100%}
 
-</style>
+  .centered {
+    margin: auto 0px;
+    text-align: center;
+  }
+
+  </style>
+</head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
 <table><tr><td valign="top">
   <table id="galileo"></table></td><td valign="top">
 
   <div class="Orbits">
-    <center>
+    <div class="centered">
       <div class="Drawing"></div>
-    </center>
+    </div>
   </div>
   </td></tr></table>
   

--- a/html/observers.html
+++ b/html/observers.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
   <title>galmon.eu observers</title>
   <meta charset="utf-8">

--- a/html/observers.html
+++ b/html/observers.html
@@ -1,45 +1,48 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
+<head>
+  <title>galmon.eu observers</title>
+  <meta charset="utf-8">
+  <style>
 
-text {
-  font: 12px sans-serif;
-}
+  text {
+    font: 12px sans-serif;
+  }
 
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
 
-.CellWithComment{
-  position:relative;
-}
+  .CellWithComment{
+    position:relative;
+  }
 
-.CellComment{
-  display:none;
-  position:absolute; 
-  z-index:100;
-  border:1px;
-  background-color:white;
-  border-style:solid;
-  border-width:1px;
-  border-color:red;
-  padding:3px;
-  color:red; 
-  top:20px; 
-  left:20px;
-}
+  .CellComment{
+    display:none;
+    position:absolute; 
+    z-index:100;
+    border:1px;
+    background-color:white;
+    border-style:solid;
+    border-width:1px;
+    border-color:red;
+    padding:3px;
+    color:red; 
+    top:20px; 
+    left:20px;
+  }
 
-.CellWithComment:hover span.CellComment{
-  display:block;
-}
+  .CellWithComment:hover span.CellComment{
+    display:block;
+  }
 
-</style>
+  </style>
+</head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
   <table id="galileo"></table>

--- a/html/observers.html
+++ b/html/observers.html
@@ -16,8 +16,8 @@
   padding-bottom: 1px;
   font-family: monospace;
   }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
+  tr:nth-child(even) {background: #BFBFBF}
+  tr:nth-child(odd) {background: #E6E6E6}
 
   .CellWithComment{
     position:relative;

--- a/html/observers.html
+++ b/html/observers.html
@@ -56,9 +56,9 @@
 
     For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
     <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
-    
-    <script src="d3.v4.min.js"></script>
-    <script src="ext/moment-with-locales.js"></script>
+  </p>
+  <script src="d3.v4.min.js"></script>
+  <script src="ext/moment-with-locales.js"></script>
   <script src="observers.js"></script>
 </body>
 </html>

--- a/html/overview.html
+++ b/html/overview.html
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<html lang="en">
 <head>
   <title>galmon.eu overview</title>
   <meta charset="utf-8">

--- a/html/overview.html
+++ b/html/overview.html
@@ -16,8 +16,8 @@
   padding-bottom: 1px;
   font-family: monospace;
   }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
+  tr:nth-child(even) {background: #BFBFBF}
+  tr:nth-child(odd) {background: #E6E6E6}
 
   .CellWithComment{
     position:relative;

--- a/html/overview.html
+++ b/html/overview.html
@@ -1,45 +1,48 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
+<head>
+  <title>galmon.eu overview</title>
+  <meta charset="utf-8">
+  <style>
 
-text {
-  font: 12px sans-serif;
-}
+  text {
+    font: 12px sans-serif;
+  }
 
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
+  th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+  }
+  tr:nth-child(even) {background: #CCC}
+  tr:nth-child(odd) {background: #FFF}
 
-.CellWithComment{
-  position:relative;
-}
+  .CellWithComment{
+    position:relative;
+  }
 
-.CellComment{
-  display:none;
-  position:absolute; 
-  z-index:100;
-  border:1px;
-  background-color:white;
-  border-style:solid;
-  border-width:1px;
-  border-color:red;
-  padding:3px;
-  color:red; 
-  top:20px; 
-  left:20px;
-}
+  .CellComment{
+    display:none;
+    position:absolute; 
+    z-index:100;
+    border:1px;
+    background-color:white;
+    border-style:solid;
+    border-width:1px;
+    border-color:red;
+    padding:3px;
+    color:red; 
+    top:20px; 
+    left:20px;
+  }
 
-.CellWithComment:hover span.CellComment{
-  display:block;
-}
+  .CellWithComment:hover span.CellComment{
+    display:block;
+  }
 
-</style>
+  </style>
+</head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
   <table id="galileo"></table>


### PR DESCRIPTION
- Multiple various fixed to ensure compliance with W3C standards compliance, eg
  - Removing nested block tags
  - Switching ampersands to URL escaped sequences
  - Adding ```<head>``` and ```<title>``` tags since title cannot be inferred from protocol
  - Alter obsolete doctags
  - Standardize utf-8 charset
 
- Standardization of HTML to 2-space in line with Google HTML/CSS Style Guide / W3C recommendation

- Minor feature improvement requested, altering background color for table elements