### PR TITLE
startup script/systemd cleanup

### DIFF
--- a/Dockerfile-pi
+++ b/Dockerfile-pi
@@ -1,0 +1,18 @@
+#FROM ubuntu:disco
+FROM arm32v7/debian:unstable
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+
+# Update packages and install dependencies
+RUN apt-get update && apt-get -y upgrade && apt-get -y clean
+RUN apt-get install -y protobuf-compiler libh2o-dev libcurl4-openssl-dev \
+        libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev libeigen3-dev \
+	make clang-9 build-essential curl autoconf automake libfmt-dev libncurses5-dev \
+    && apt-get -y clean
+
+# Build
+ADD . /galmon/
+WORKDIR /galmon/
+RUN make 
+ENV PATH=/galmon:${PATH}

--- a/README.md
+++ b/README.md
@@ -182,7 +182,7 @@ This allows anyone to send you frames, so be aware.
 Next up, run `navnexus ./storage ::`, which will serve your recorded data from port 29601. It will merge messages
 coming in from all sources and serve them in time order.
 
-Finally, you can do `nv 127.0.0.1 29601 | ./navdump`, which will give you all messages over the past 24 hours, and stream you more.
+Finally, you can do `nc 127.0.0.1 29601 | ./navdump`, which will give you all messages over the past 24 hours, and stream you more.
 This also works for `navparse` for the pretty website and influx storage, `nc 127.0.0.1 29601 | ./navparse 127.0.0.0:10000 html galileo`,
 if you have an influxdb running on localhost with a galileo database in there.
 
@@ -254,6 +254,7 @@ In alphabetical order:
  * Spain
  * Tonga 
  * USA
+   * Alaska (Anchorage)
    * California (Santa Cruz, Los Angeles area, etc)
    * Massachusetts (Boston area)
  * Uruguay

--- a/ubxtool.service
+++ b/ubxtool.service
@@ -7,10 +7,11 @@ StartLimitIntervalSec=0
 Type=simple
 Restart=always
 RestartSec=1
+# uncomment User and Group to not run as root
 #User=ubxtool
 #Group=ubxtool
-#DynamicUser=yes
-#RuntimeDirectory=ubxtool
+RuntimeDirectory=ubxtool
+RuntimeDirectoryPreserve=yes
 WorkingDirectory=/run/ubxtool
 ExecStart=/usr/local/ubxtool/ubxtool.sh
 


### PR DESCRIPTION
I've adjusted the systemd service file so that it correctly creates the runtime/working directory as needed, and it will automatically set the ownership correctly based on the settings. 

Additionally, the service script has been rewritten to enable auto-detection of the serial interface, as well as have a cleaner log-rotation setup.
