### PR TITLE
Consolidate all main page CSS into styles.css

### DIFF
--- a/html/almanac.html
+++ b/html/almanac.html
@@ -3,23 +3,7 @@
 <head>
   <title>galmon.eu almanac</title>
   <meta charset="utf-8">
-  <style>
-
-  text {
-    font: 12px sans-serif;
-  }
-
-
-  th, td {
-    padding-left: 8px;
-    padding-right: 8px;
-    padding-top: 1px;
-    padding-bottom: 1px;
-    font-family: monospace;
-  }
-  tr:nth-child(even) {background: #BFBFBF}
-  tr:nth-child(odd) {background: #E6E6E6}
-  </style>
+  <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
   Last update: <span id="freshness"></span><br/>

--- a/html/index.html
+++ b/html/index.html
@@ -3,62 +3,7 @@
 <head>
   <meta charset="utf-8">
   <title>galmon.eu</title>
-  <style>
-  text {
-    font: 12px sans-serif;
-  }
-
-  th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
-  }
-  tr:nth-child(even) {background: #BFBFBF}
-  tr:nth-child(odd) {background: #E6E6E6}
-
-  label {
-     cursor: pointer;
-  }
-  input[type="checkbox"] {
-     cursor: pointer;
-  }
-
-
-  .CellWithComment{
-    position:relative;
-  }
-
-  .CellComment{
-    display:none;
-    position:absolute; 
-    z-index:100;
-    border:1px;
-    background-color:white;
-    border-style:solid;
-    border-width:1px;
-    border-color:red;
-    padding:3px;
-    color:red; 
-    top:20px; 
-    left:20px;
-  }
-
-  .CellWithComment:hover span.CellComment{
-    display:block;
-  }
-
-  .centered {
-    margin: auto 0px;
-    text-align: center;
-  }
-
-  #fields tr {
-    vertical-align:top;
-  }
-
-  </style>
+  <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a> and <a href="https://berthub.eu/articles/posts/gps-gnss-how-do-they-work/">here</a>. Live observer map <a href="geo">here</a>, status (coverage, DOP) map <a href="geo/coverage.html">here</a>. Contact <a href="https://berthub.eu/">me</a> if you want access to the Grafana dashboard.<br/>

--- a/html/observer.html
+++ b/html/observer.html
@@ -3,42 +3,24 @@
 <head>
   <title>galmon.eu observer</title>
   <meta charset="utf-8">
-  <style>
-
-  text {
-    font: 12px sans-serif;
-  }
-
-  th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
-  }
-  tr:nth-child(even) {background: #CCC}
-  tr:nth-child(odd) {background: #FFF}
-
-  .Orbits{margin-top:3em;margin-bottom:1em}.Orbits .Variables{display:inline-block;vertical-align:top;width:28em;height:44em;overflow:auto;position:relative}.Orbits .Variables table{font-family:'Roboto Mono',monospace;color:#000;border-spacing:.5em;display:block;position:absolute;left:50%;transform:translateX(-50%)}.Orbits .Variables table tr{text-align:center}.Orbits .Variables table td{font-size:.85em}.Orbits .Drawing{display:inline-block;vertical-align:top;margin-top:.5em;width:44em;height:44em}.Orbits .Drawing .sats-label{font-size:12px;fill:#454545;font-weight:bold;stroke:transparent}.Orbits .Drawing .satellite circle{stroke-width:2px}.Orbits .Drawing svg{font-family:sans-serif;font-size:10px;text-anchor:middle;fill:none;stroke:#000;width:100%;height:100%}
-
-  .centered {
-    margin: auto 0px;
-    text-align: center;
-  }
-
-  </style>
+  <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
-<table><tr><td style="vertical-align:top">
-  <table id="galileo"></table></td><td style="vertical-align:top">
-
-  <div class="Orbits">
-    <div class="centered">
-      <div class="Drawing"></div>
-    </div>
-  </div>
-  </td></tr></table>
+  <table>
+    <tr style="background: #FFF">
+      <td style="vertical-align:top">
+        <table id="galileo"></table>
+      </td>
+      <td style="vertical-align:top">
+        <div class="Orbits">
+          <div class="centered">
+            <div class="Drawing"></div>
+          </div>
+        </div>
+      </td>
+    </tr>
+  </table>
   
   <p>
     This table shows live output from four Galileo/GPS/BeiDou/GLONASS receivers hosted in Nootdorp, The Netherlands and California, United States.
@@ -49,9 +31,10 @@
 
     For updates, follow <a href="https://twitter.com/GalileoSats">@GalileoSats</a> on Twitter, or join us on our IRC channel (chat) via the
     <a href="https://webchat.oftc.net/?channels=galileo">web gateway</a>.
-    
-    <script src="d3.v4.min.js"></script>
-    <script src="ext/moment-with-locales.js"></script>
+  </p>
+
+  <script src="d3.v4.min.js"></script>
+  <script src="ext/moment-with-locales.js"></script>
   <script src="observer.js"></script>
 </body>
 </html>

--- a/html/observers.html
+++ b/html/observers.html
@@ -3,46 +3,7 @@
 <head>
   <title>galmon.eu observers</title>
   <meta charset="utf-8">
-  <style>
-
-  text {
-    font: 12px sans-serif;
-  }
-
-  th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
-  }
-  tr:nth-child(even) {background: #BFBFBF}
-  tr:nth-child(odd) {background: #E6E6E6}
-
-  .CellWithComment{
-    position:relative;
-  }
-
-  .CellComment{
-    display:none;
-    position:absolute; 
-    z-index:100;
-    border:1px;
-    background-color:white;
-    border-style:solid;
-    border-width:1px;
-    border-color:red;
-    padding:3px;
-    color:red; 
-    top:20px; 
-    left:20px;
-  }
-
-  .CellWithComment:hover span.CellComment{
-    display:block;
-  }
-
-  </style>
+  <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>

--- a/html/overview.html
+++ b/html/overview.html
@@ -3,46 +3,7 @@
 <head>
   <title>galmon.eu overview</title>
   <meta charset="utf-8">
-  <style>
-
-  text {
-    font: 12px sans-serif;
-  }
-
-  th, td {
-  padding-left: 8px;
-  padding-right: 8px;
-  padding-top: 1px;
-  padding-bottom: 1px;
-  font-family: monospace;
-  }
-  tr:nth-child(even) {background: #BFBFBF}
-  tr:nth-child(odd) {background: #E6E6E6}
-
-  .CellWithComment{
-    position:relative;
-  }
-
-  .CellComment{
-    display:none;
-    position:absolute; 
-    z-index:100;
-    border:1px;
-    background-color:white;
-    border-style:solid;
-    border-width:1px;
-    border-color:red;
-    padding:3px;
-    color:red; 
-    top:20px; 
-    left:20px;
-  }
-
-  .CellWithComment:hover span.CellComment{
-    display:block;
-  }
-
-  </style>
+  <link rel="stylesheet" type="text/css" href="style.css">
 </head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>

--- a/html/style.css
+++ b/html/style.css
@@ -1,0 +1,120 @@
+text {
+  font: 12px sans-serif;
+}
+
+th, td {
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 1px;
+  padding-bottom: 1px;
+  font-family: monospace;
+}
+
+tr:nth-child(even) {
+  background: #BFBFBF
+}
+
+tr:nth-child(odd) {
+  background: #E6E6E6
+}
+
+label {
+   cursor: pointer;
+}
+
+input[type="checkbox"] {
+   cursor: pointer;
+}
+
+.CellWithComment {
+  position:relative;
+}
+
+.CellComment {
+  display:none;
+  position:absolute; 
+  z-index:100;
+  border:1px;
+  background-color:white;
+  border-style:solid;
+  border-width:1px;
+  border-color:red;
+  padding:3px;
+  color:red; 
+  top:20px; 
+  left:20px;
+}
+
+.CellWithComment:hover span.CellComment {
+  display:block;
+}
+
+.centered {
+  margin: auto 0px;
+  text-align: center;
+}
+
+#fields tr {
+  vertical-align:top;
+}
+
+.Orbits {
+  margin-top:3em;
+  margin-bottom:1em;
+}
+
+.Orbits .Variables {
+  display:inline-block;
+  vertical-align:top;
+  width:28em;
+  height:44em;
+  overflow:auto;
+  position:relative;
+}
+
+.Orbits .Variables table {
+  font-family:'Roboto Mono',monospace;
+  color:#000;
+  border-spacing:.5em;
+  display:block;
+  position:absolute;
+  left:50%;
+  transform:translateX(-50%);
+}
+
+.Orbits .Variables table tr {
+  text-align:center;
+}
+
+.Orbits .Variables table td {
+  font-size:.85em;
+}
+
+.Orbits .Drawing {
+  display:inline-block;
+  vertical-align:top;
+  margin-top:.5em;
+  width:44em;
+  height:44em;
+}
+
+.Orbits .Drawing .sats-label {
+  font-size:12px;
+  fill:#454545;
+  font-weight:bold;
+  stroke:transparent;
+}
+
+.Orbits .Drawing .satellite circle {
+  stroke-width:2px;
+}
+
+.Orbits .Drawing svg {
+  font-family:sans-serif;
+  font-size:10px;
+  text-anchor:middle;
+  fill:none;
+  stroke:#000;
+  width:100%;
+  height:100%;
+}

--- a/html/sv.html
+++ b/html/sv.html
@@ -1,45 +1,10 @@
 <!DOCTYPE html>
-<meta charset="utf-8">
-<style>
-
-text {
-  font: 12px sans-serif;
-}
-
-th, td {
-padding-left: 8px;
-padding-right: 8px;
-padding-top: 1px;
-padding-bottom: 1px;
-font-family: monospace;
-}
-tr:nth-child(even) {background: #CCC}
-tr:nth-child(odd) {background: #FFF}
-
-.CellWithComment{
-  position:relative;
-}
-
-.CellComment{
-  display:none;
-  position:absolute; 
-  z-index:100;
-  border:1px;
-  background-color:white;
-  border-style:solid;
-  border-width:1px;
-  border-color:red;
-  padding:3px;
-  color:red; 
-  top:20px; 
-  left:20px;
-}
-
-.CellWithComment:hover span.CellComment{
-  display:block;
-}
-
-</style>
+<html lang="en">
+<head>
+  <title>galmon.eu sv</title>
+  <meta charset="utf-8">
+  <link rel="stylesheet" type="text/css" href="style.css">
+</head>
 <body>
   Last update: <span id="freshness"></span>. More information about this Galileo/GPS/BeiDou/Glonass open source monitor can be found <a href="https://github.com/ahupowerdns/galmon/blob/master/README.md#galmon">here</a>. Live map <a href="geo">here!</a>. Contact <a href="https://ds9a.nl/">me</a> if you want access to the Grafana dashboard.<br/>
   <table id="galileo"></table>


### PR DESCRIPTION
- Consolidated all CSS into styles.css in main index (observers, observer, index, etc) for ease of future maintenance

- Fixed issue caused by non-consolidated CSS where old table CSS formatting still persisted on observer page _(eg, [here](https://galmon.eu/observer.html?observer=4) does not have correct styling on table rows to differentiate from background)_