### PR TITLE
Update README for docker steps & ubxtool now manadatory commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Running
 -------
 
 Once compiled, run for example `./ubxtool --wait --port /dev/ttyACM0
---station 1 --stdout | ./navparse 127.0.0.1:10000 html null`
+--station 1 --stdout --galileo | ./navparse 127.0.0.1:10000 html null`
 
 Next up, browse to http://[::1]:10000 (or try http://localhost:10000/ and
 you should be in business. ubxtool changes (non-permanently) the
@@ -120,13 +120,13 @@ the `--ubxport <id>` option using one of the following numeric IDs:
 To see what is going on, try:
 
 ```
-./ubxtool --wait --port /dev/ttyACM0 --station 1 --stdout | ./navdump
+./ubxtool --wait --port /dev/ttyACM0 --station 1 --stdout --galileo | ./navdump
 ```
 
 To distribute data to a remote `navrecv`, use:
 
 ```
-./ubxtool --wait --port /dev/ttyACM0 --station 255 --dest 127.0.0.1
+./ubxtool --wait --port /dev/ttyACM0 --galileo --station 255 --dest 127.0.0.1
 ```
 
 This will send protobuf to 127.0.0.1:29603. You can add as many destinations

--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ git clone https://github.com/ahupowerdns/galmon.git --recursive
 docker build -t galmon --build-arg MAKE_FLAGS=-j2 .
 ```
 
-To run a container with a shell in there:
+To run a container with a shell in there (this will also expose a port so you can view the UI too and assumes a ublox GPS device too - you may need to tweak as necessary):
 
 ```
-docker run -it --rm galmon
+docker run -it --rm --device=/dev/ttyACM0 -p 10000:10000 galmon
 ```
 
 


### PR DESCRIPTION
Just some simple updates to the README.md to:

- Add in Galileo as a default for reception in ubxtool (since at least one is now required)
- Update Docker run steps to passthrough a USB ublox device and enable port forwarding so you can view the UI remotely