### PR TITLE
navparse.cc: Round observed azimuth & elevation values to 1 d.p. in 'svs.json' and 'observers.json' web data files. Closes issue #49.

### DIFF
--- a/navparse.cc
+++ b/navparse.cc
@@ -893,8 +893,8 @@ try
               nlohmann::json svo = nlohmann::json::object();
               svo["db"] = iter->second.db;
 
-              svo["elev"] = iter->second.el;
-              svo["azi"] = iter->second.azi;
+              svo["elev"] = roundf(10.0*iter->second.el)/10.0;
+              svo["azi"] = roundf(10.0*iter->second.azi)/10.0;
 
               Point sat;
               
@@ -910,8 +910,8 @@ try
               }
               if(sat.x) {
                 Point our = g_srcpos[iter->first].pos;
-                svo["elev"] = getElevationDeg(sat, our);
-                svo["azi"] = getAzimuthDeg(sat, our);
+                svo["elev"] = roundf(10.0*getElevationDeg(sat, our))/10.0;
+                svo["azi"] = roundf(10.0*getAzimuthDeg(sat, our))/10.0;
               }
 
               
@@ -1395,8 +1395,8 @@ try
 
             if(sat.x) {
               Point our = g_srcpos[pr.first].pos;
-              det["elev"] = getElevationDeg(sat, our);
-              det["azi"] = getAzimuthDeg(sat, our);
+              det["elev"] = roundf(10.0*getElevationDeg(sat, our))/10.0;
+              det["azi"] = roundf(10.0*getAzimuthDeg(sat, our))/10.0;
             }
             else
               det["elev"] = pr.second.el;


### PR DESCRIPTION
Note that the values inserted into InfluxDB have not been altered, this only affects the values served for 'svs.json' and 'observers.json'.