### PR TITLE
Build tiny `ubxtool` docker image and a binary depending on just glibc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ navrecv
 testrunner
 tlecatch
 ubxtool
+ubxtool.nodeps
+ubxtool.nodeps.*
 # - created by update-tles
 active.txt
 beidou.txt

--- a/Dockerfile.ubxtool
+++ b/Dockerfile.ubxtool
@@ -1,0 +1,30 @@
+# See `build-ubxtool` script for cross-compilation options.
+FROM ubuntu:bionic AS build-env
+
+ENV DEBIAN_FRONTEND noninteractive
+ENV LC_ALL C.UTF-8
+
+# This allows you to use a local Ubuntu mirror
+ARG APT_URL=
+ENV APT_URL ${APT_URL:-mirror://mirrors.ubuntu.com/mirrors.txt}
+RUN set -ex && \
+    sed -i "s%http://archive.ubuntu.com/ubuntu/%${APT_URL}%" /etc/apt/sources.list && \
+    apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        build-essential \
+        g++ \
+        libprotobuf-dev \
+        make \
+        protobuf-compiler \
+    && \
+    apt-get -y clean && \
+    :
+
+ADD . /galmon/
+WORKDIR /galmon
+RUN make ubxtool.nodeps
+
+FROM busybox:glibc
+COPY --from=build-env /galmon/ubxtool.nodeps /opt/ubxtool
+ENTRYPOINT ["/opt/ubxtool"]

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ H2OPP=ext/powerblog/h2o-pp.o
 SIMPLESOCKETS=ext/powerblog/ext/simplesocket/swrappers.o ext/powerblog/ext/simplesocket/sclasses.o  ext/powerblog/ext/simplesocket/comboaddress.o 
 
 clean:
-	rm -f *~ *.o *.d ext/*/*.o $(PROGRAMS) navmon.pb.h navmon.pb.cc $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) $(H2OPP) $(SIMPLESOCKETS)
+	rm -f *~ *.o *.d ext/*/*.o $(PROGRAMS) ubxtool.nodeps* navmon.pb.h navmon.pb.cc $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) $(H2OPP) $(SIMPLESOCKETS)
 	rm -f ext/fmt-5.2.1/src/format.o
 
 
@@ -52,8 +52,13 @@ tlecatch: tlecatch.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc))
 navmon.pb.cc: navmon.proto
 	protoc --cpp_out=./ navmon.proto
 
-ubxtool: navmon.pb.o ubxtool.o ubx.o bits.o ext/fmt-5.2.1/src/format.o galileo.o  gps.o beidou.o navmon.o ephemeris.o $(SIMPLESOCKETS) osen.o
+UBXTOOL_DEPS = navmon.pb.o ubxtool.o ubx.o bits.o ext/fmt-5.2.1/src/format.o galileo.o  gps.o beidou.o navmon.o ephemeris.o $(SIMPLESOCKETS) osen.o
+
+ubxtool: $(UBXTOOL_DEPS)
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -lprotobuf -pthread
+# Static linking of `glibc` is non-trivial, so glibc is kept dynamically linked
+ubxtool.nodeps: $(UBXTOOL_DEPS)
+	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib /usr/lib/*-linux-*/libprotobuf.a -pthread -static-libgcc -static-libstdc++
 
 testrunner: navmon.pb.o testrunner.o ubx.o bits.o ext/fmt-5.2.1/src/format.o galileo.o  gps.o beidou.o ephemeris.o sp3.o osen.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -lprotobuf

--- a/README.md
+++ b/README.md
@@ -94,6 +94,23 @@ To run a container with a shell in there:
 docker run -it --rm galmon
 ```
 
+Build `ubxtool` in Docker
+-------------------------
+
+To build a minimal `ubxtool` docker image:
+
+```
+git clone https://github.com/ahupowerdns/galmon.git --recursive
+./build-ubxtool native
+```
+
+It may also cross-compile a binary and an image for a Raspberry Pi:
+
+```
+git clone https://github.com/ahupowerdns/galmon.git --recursive
+docker run -it --rm --privileged multiarch/qemu-user-static:register --reset
+./build-ubxtool armhf
+```
 
 Running
 -------

--- a/build-ubxtool
+++ b/build-ubxtool
@@ -1,0 +1,33 @@
+#!/bin/bash
+#
+# The script relies on the following project:
+# - https://github.com/multiarch/qemu-user-static
+# - https://github.com/multiarch/ubuntu-core
+#
+# Another easy cross-compilation option is to use https://github.com/docker/binfmt
+#
+# Register qemu-user-static before building
+# $ docker run --rm --privileged multiarch/qemu-user-static:register --reset
+
+set -e
+
+arch=${1:-native}
+
+case "$arch" in
+    native)
+        tag=latest
+        from=ubuntu:bionic
+    ;;
+    x86|x86_64|arm64|armhf)
+        tag=${arch}
+        from=multiarch/ubuntu-core:${arch}-bionic
+    ;;
+    *)
+    echo "$0: unknown arch <$arch>, known are: (native|x86|x86_64|arm64|armhf)" 1>&2
+    exit 1
+esac
+
+sed "s,^FROM ubuntu:bionic AS,FROM ${from} AS," Dockerfile.ubxtool | docker build -f - --tag ubxtool:${tag} .
+cntr=$(docker create ubxtool:${tag})
+docker cp ${cntr}:/opt/ubxtool ./ubxtool.nodeps.${tag}
+docker rm ${cntr}


### PR DESCRIPTION
That's useful to avoid native compilation on a Raspberry Pi itself while running a galmon probe.

That may also kinda reduce @akhepcat's pain of slow native compilation on RPi mentioned at #48.

Please, tell me if `build-ubxtool` should rather be a Makefile target.