### PR TITLE
Install git during docker build so update-git-hash-if-necessary works.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN sed -i "s%http://archive.ubuntu.com/ubuntu/%${APT_URL}%" /etc/apt/sources.li
 RUN apt-get update && apt-get -y upgrade && apt-get -y clean
 RUN apt-get install -y protobuf-compiler libh2o-dev libcurl4-openssl-dev \
         libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev libeigen3-dev \
-	make gcc g++ build-essential curl autoconf automake libfmt-dev libncurses5-dev \
+	make gcc g++ git build-essential curl autoconf automake libfmt-dev libncurses5-dev \
     && apt-get -y clean
 
 # Build

--- a/Dockerfile-pi
+++ b/Dockerfile-pi
@@ -8,7 +8,7 @@ ENV LC_ALL C.UTF-8
 RUN apt-get update && apt-get -y upgrade && apt-get -y clean
 RUN apt-get install -y protobuf-compiler libh2o-dev libcurl4-openssl-dev \
         libssl-dev libprotobuf-dev libh2o-evloop-dev libwslay-dev libeigen3-dev \
-	make clang-9 build-essential curl autoconf automake libfmt-dev libncurses5-dev \
+	make clang-9 git build-essential curl autoconf automake libfmt-dev libncurses5-dev \
     && apt-get -y clean
 
 # Build


### PR DESCRIPTION
If git CLI tool isn't installed, then `update-git-hash-if-necessary` will generate an empty `GIT_HASH`.