### PR TITLE
navdump: don't warn about types 10 & 11

### DIFF
--- a/navdump.cc
+++ b/navdump.cc
@@ -655,6 +655,12 @@ try
       cout<<endl;
       
     }
+    else if(nmm.type() == NavMonMessage::DebuggingType) {
+      /* reserved for future use */
+    }
+    else if(nmm.type() == NavMonMessage::ObserverDetailsType) {
+      /* reserved for future use */
+    }
     else {
       etstamp();
       cout<<"Unknown type "<< (int)nmm.type()<<endl;

--- a/navparse.cc
+++ b/navparse.cc
@@ -2043,6 +2043,12 @@ try
       }
       //      cout<<"GLONASS R"<<id.second<<" str "<<strno<<endl;
     }
+    else if(nmm.type() == NavMonMessage::DebuggingType) {
+      /* reserved for future use */
+    }
+    else if(nmm.type() == NavMonMessage::ObserverDetailsType) {
+      /* reserved for future use */
+    }
     else {
       cout<<"Unknown type "<< (int)nmm.type()<<endl;
     }


### PR DESCRIPTION
They are used by ubxtool to inform galmon.eu about various receiver
information but navdump doesn't yet know how to handle them.  Instead of
generating tons of warnings, let's just silently ignore them for now.