### PR TITLE
Update doalles.js - added color coding

### DIFF
--- a/html/doalles.js
+++ b/html/doalles.js
@@ -88,18 +88,22 @@ function maketable(str, arr)
                         ret.value="";
                 }
                 else if(row[column] != null && (column == "delta_hz_corr" || column =="delta_hz")) {
-
                     ret.value = row[column];
                 }
                 else if((column == "tle-dist")) {
-                    if(row["best-tle-dist"] != null)
+                    if(row["best-tle-dist"] != null) {
                         ret.value = row["best-tle-dist"].toFixed(1) + " km";
+
+                        if (Math.abs(row["best-tle-dist"]) > 10000)
+                            ret.color="red";
+                        else if (Math.abs(row["best-tle-dist"]) > 1000)
+                            ret.color="#ffaaaa";
+                    } 
                 }
                 else if((column == "alma-dist")) {
                     if(row["alma-dist"] != null)
                         ret.value = row["alma-dist"].toFixed(1) + " km";
                 }
-
                 else if(column == "norad") {
                     ret.value = row["best-tle-norad"];
                 }


### PR DESCRIPTION
added color coding to indicate large best-tle-dist -values. Bright red for 10000+ km and light red for 1000+ km.

This makes it easier to spot obviously faulty tle-estimates.