### PR TITLE
Set ublox8 receivers from 'Balanced' to 'Full Power' power mode.

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -770,6 +770,30 @@ int main(int argc, char** argv)
           exit(-1);
         }
       }
+
+      if(!version9) {
+        /* ublox M8 only */
+        if (doDEBUG) { cerr<<humanTimeNow()<<" Setting power mode to Full Power"<<endl; }
+
+        /* UBX-CFG-PMS, available in fw v3.01 */
+        msg = buildUbxMessage(0x06, 0x86, {
+          0x00, /* Message version = 0x00 */
+          0x00, /* Power Mode = 'Full Power' = 0x00 */
+          0x00, 0x00, /* Position update period, only valid in 'Interval' power mode, else 0 */
+          0x00, 0x00, /* Duration of ON, only valid in 'Interval' power mode, else 0 */
+          0x00, 0x00 /* Reserved */
+        });
+
+        if(sendAndWaitForUBXAckNack(fd, 10, msg, 0x06, 0x86)) {
+          if (doDEBUG) { cerr<<humanTimeNow()<<" Set power mode to Full Power successfully"<<endl; }
+        }
+        else {
+          if (doDEBUG) { cerr<<humanTimeNow()<<" GOT NACK setting power mode to Full Power"<<endl; }
+        }
+      }
+      else {
+        /* No equivalent power management found for ublox 9 ??? */
+      }
        
       if(!doKeepNMEA) {
         if (doDEBUG) { cerr<<humanTimeNow()<<" Disabling NMEA"<<endl; }


### PR DESCRIPTION
By default, ublox8 receivers are in 'Balanced' power mode, described as "Power savings without performance degradation".

This patch sets them on initialisation to 'Full Power', described as "No compromises on power saves".

Tested on a MAX-M8Q with fw 3.01, was ACKed.

This had no immediately noticeable effect, however as all of our receivers are connected to high-power hosts, I don't believe an extra few mA of power consumption will be an issue for them, and so any change can only be positive.

Despite much digging, no equivalent configuration was found for ublox9 receivers, so I've left a commented placeholder for now.