### PR TITLE
Add version CLI option for all executables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,34 +36,34 @@ clean:
 decrypt: decrypt.o bits.o ext/fmt-5.2.1/src/format.o
 	$(CXX) -std=gnu++17 $^ -o $@ 
 
-navparse: navparse.o ext/fmt-5.2.1/src/format.o $(H2OPP) $(SIMPLESOCKETS) minicurl.o ubx.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o navmon.o coverage.o osen.o trkmeas.o influxpush.o ${EXTRADEP}
+navparse: navparse.o ext/fmt-5.2.1/src/format.o $(H2OPP) $(SIMPLESOCKETS) minicurl.o ubx.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o navmon.o coverage.o osen.o trkmeas.o influxpush.o ${EXTRADEP} githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -pthread -L/usr/local/lib -L/usr/local/opt/openssl/lib/  -lh2o-evloop -lssl -lcrypto -lz  -lcurl -lprotobuf  $(WSLAY)
 
-reporter: reporter.o ext/fmt-5.2.1/src/format.o $(SIMPLESOCKETS) minicurl.o ubx.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o navmon.o coverage.o osen.o
+reporter: reporter.o ext/fmt-5.2.1/src/format.o $(SIMPLESOCKETS) minicurl.o ubx.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o navmon.o coverage.o osen.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -pthread -L/usr/local/lib -lprotobuf -lcurl
 
 galmonmon: galmonmon.o ext/fmt-5.2.1/src/format.o $(SIMPLESOCKETS) minicurl.o ubx.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o navmon.o coverage.o osen.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -pthread -L/usr/local/lib -lprotobuf -lcurl
 
 
-navdump: navdump.o ext/fmt-5.2.1/src/format.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o navmon.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o sp3.o osen.o trkmeas.o  ${EXTRADEP}
+navdump: navdump.o ext/fmt-5.2.1/src/format.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o navmon.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) tle.o sp3.o osen.o trkmeas.o githash.o ${EXTRADEP}
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread  -lprotobuf
 
-navdisplay: navdisplay.o ext/fmt-5.2.1/src/format.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o ephemeris.o navmon.o osen.o
+navdisplay: navdisplay.o ext/fmt-5.2.1/src/format.o bits.o navmon.pb.o gps.o ephemeris.o beidou.o glonass.o ephemeris.o navmon.o osen.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread  -lprotobuf -lncurses
 
 
-navnexus: navnexus.o ext/fmt-5.2.1/src/format.o  $(SIMPLESOCKETS) ubx.o bits.o navmon.pb.o storage.o
+navnexus: navnexus.o ext/fmt-5.2.1/src/format.o  $(SIMPLESOCKETS) ubx.o bits.o navmon.pb.o storage.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread -lprotobuf
 
-navcat: navcat.o ext/fmt-5.2.1/src/format.o  $(SIMPLESOCKETS) ubx.o bits.o navmon.pb.o storage.o navmon.o
+navcat: navcat.o ext/fmt-5.2.1/src/format.o  $(SIMPLESOCKETS) ubx.o bits.o navmon.pb.o storage.o navmon.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread -lprotobuf
 
 
-navrecv: navrecv.o ext/fmt-5.2.1/src/format.o $(SIMPLESOCKETS) navmon.pb.o storage.o
+navrecv: navrecv.o ext/fmt-5.2.1/src/format.o $(SIMPLESOCKETS) navmon.pb.o storage.o githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread -lprotobuf  
 
-tlecatch: tlecatch.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc))
+tlecatch: tlecatch.o $(patsubst %.cc,%.o,$(wildcard ext/sgp4/libsgp4/*.cc)) githash.o
 	$(CXX) -std=gnu++17 $^ -o $@ -L/usr/local/lib -pthread -lprotobuf  
 
 navmon.pb.cc: navmon.proto

--- a/galmonmon.cc
+++ b/galmonmon.cc
@@ -16,11 +16,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 /*
   Monitoring the satellites for sensible alerts.
 
@@ -189,7 +184,7 @@ int main(int argc, char **argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/galmonmon.cc
+++ b/galmonmon.cc
@@ -7,7 +7,19 @@
 #include "ext/powerblog/h2o-pp.hh"
 #include <variant>
 #include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="galmonmon";
+
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 /*
   Monitoring the satellites for sensible alerts.
@@ -164,14 +176,28 @@ int main(int argc, char **argv)
   MiniCurl::MiniCurlHeaders mch;
   //  string url="https://galmon.eu/svs.json";
   string url="http://[::1]:10000/";
-  
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   g_sk.setBoolNames("health", "healthy", "unhealthy");
   g_sk.setBoolNames("eph-too-old", "ephemeris fresh", "ephemeris too old");
   g_sk.setBoolNames("silent", "observed", "not observed");
 
   std::variant<bool, string> tst;
-
-  extern const char* g_gitHash;
 
   auto observers = nlohmann::json::parse(mc.getURL(url+"observers.json"));
   

--- a/navcat.cc
+++ b/navcat.cc
@@ -16,8 +16,20 @@
 #include <dirent.h>
 #include <inttypes.h>
 #include "navmon.hh"
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="navcat";
 
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 void unixDie(const std::string& str)
 {
@@ -163,6 +175,23 @@ void sendProtobuf(string_view dir, time_t startTime, time_t stopTime=0)
 
 int main(int argc, char** argv)
 {
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   signal(SIGPIPE, SIG_IGN);
   if(argc < 3) {
     cout<<"Syntax: navcat storage start stop"<<endl;

--- a/navcat.cc
+++ b/navcat.cc
@@ -26,11 +26,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 void unixDie(const std::string& str)
 {
   throw std::runtime_error(str+string(": ")+string(strerror(errno)));
@@ -188,7 +183,7 @@ int main(int argc, char** argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/navdisplay.cc
+++ b/navdisplay.cc
@@ -23,11 +23,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 struct WinKeeper
 {
   WinKeeper();
@@ -148,11 +143,26 @@ void WinKeeper::setStatus(int sv, std::string_view line)
 }
 
 
-int main()
+int main(int argc, char** argv)
 {
-  WinKeeper wk;
-  
+  bool doVERSION{false};
 
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion(program, g_gitHash);
+    exit(0);
+  }
+
+  WinKeeper wk;
   for(;;) {
     char bert[4];
     if(readn2(0, bert, 4) != 4 || bert[0]!='b' || bert[1]!='e' || bert[2] !='r' || bert[3]!='t') {

--- a/navdisplay.cc
+++ b/navdisplay.cc
@@ -13,8 +13,20 @@
 #include "navmon.pb.h"
 #include <unistd.h>
 #include "navmon.hh" 
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="navdisplay";
+
 using namespace std;
 
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 struct WinKeeper
 {

--- a/navdump.cc
+++ b/navdump.cc
@@ -35,11 +35,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 Point g_ourpos;
 
 
@@ -272,7 +267,7 @@ try
     return app.exit(e);
   }
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
   SVFilter svfilter;

--- a/navdump.cc
+++ b/navdump.cc
@@ -26,7 +26,19 @@
 #include "sp3.hh"
 #include "ubx.hh"
 #include <unistd.h>
+#include "githash.h"
+#include "version.hh"
+
+static char program[]="navdump";
+
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 Point g_ourpos;
 
@@ -226,7 +238,7 @@ try
 {
   GOOGLE_PROTOBUF_VERIFY_VERSION;
 
-  CLI::App app("navdump");
+  CLI::App app(program);
 
   
   TLERepo tles;
@@ -247,15 +259,21 @@ try
   bool doReceptionData{false};
   bool doRFData{true};
   bool doObserverPosition{false};
+  bool doVERSION{false};
   app.add_option("--svs", svpairs, "Listen to specified svs. '0' = gps, '2' = Galileo, '2,1' is E01");
   app.add_option("--stations", stations, "Listen to specified stations.");
   app.add_option("--positions,-p", doObserverPosition, "Print out observer positions (or not)");
   app.add_option("--rfdata,-r", doRFData, "Print out RF data (or not)");
+  app.add_flag("--version", doVERSION, "show program version and copyright");
     
   try {
     app.parse(argc, argv);
   } catch(const CLI::Error &e) {
     return app.exit(e);
+  }
+  if(doVERSION) {
+    showVersion();
+    exit(0);
   }
   SVFilter svfilter;
   for(const auto& svp : svpairs) {

--- a/navnexus.cc
+++ b/navnexus.cc
@@ -15,8 +15,21 @@
 #include "storage.hh"
 #include <dirent.h>
 #include <inttypes.h>
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="navnexus";
 
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
+
 
 std::mutex g_clientmut;
 set<int> g_clients;
@@ -143,6 +156,23 @@ void sendListener(Socket&& s, ComboAddress local, int hours)
 
 int main(int argc, char** argv)
 {
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   signal(SIGPIPE, SIG_IGN);
   if(argc < 3) {
     cout<<"Syntax: navnexus storage listen-address [backlog-hours]"<<endl;

--- a/navnexus.cc
+++ b/navnexus.cc
@@ -25,12 +25,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
-
 std::mutex g_clientmut;
 set<int> g_clients;
 
@@ -169,7 +163,7 @@ int main(int argc, char** argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/navparse.cc
+++ b/navparse.cc
@@ -30,8 +30,20 @@
 #include "navparse.hh"
 #include <fenv.h> 
 #include "influxpush.hh"
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="navparse";
 
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 struct ObserverPosition
 {
@@ -415,6 +427,23 @@ void addHeaders(h2o_req_t* req)
 int main(int argc, char** argv)
 try
 {
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   //  feenableexcept(FE_DIVBYZERO | FE_INVALID | FE_OVERFLOW ); 
 
   

--- a/navparse.cc
+++ b/navparse.cc
@@ -40,11 +40,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 struct ObserverPosition
 {
   Point pos;
@@ -440,7 +435,7 @@ try
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/navrecv.cc
+++ b/navrecv.cc
@@ -21,11 +21,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 /* Goals in life:
 
    1) NEVER EVER GO DOWN
@@ -207,7 +202,7 @@ int main(int argc, char** argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/navrecv.cc
+++ b/navrecv.cc
@@ -11,7 +11,20 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="navrecv";
+
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 /* Goals in life:
 
@@ -181,6 +194,23 @@ void recvListener(Socket&& s, ComboAddress local)
 
 int main(int argc, char** argv)
 {
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   signal(SIGPIPE, SIG_IGN);
   if(argc != 3) {
     cout<<"Syntax: navrecv listen-address storage"<<endl;

--- a/reporter.cc
+++ b/reporter.cc
@@ -14,11 +14,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 /*
   Goal: generate statistics from influxdb.
 
@@ -70,7 +65,7 @@ int main(int argc, char **argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/reporter.cc
+++ b/reporter.cc
@@ -4,8 +4,20 @@
 #include "navmon.hh"
 #include "fmt/format.h"
 #include "fmt/printf.h"
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="reporter";
 
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
 
 /*
   Goal: generate statistics from influxdb.
@@ -45,6 +57,23 @@ int main(int argc, char **argv)
   string url="http://127.0.0.1:8086/query?db="+dbname+"&epoch=s&q=";
   string period="time > now() - 1w";
   int sigid=1;
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   if(argc == 2)
     period = "time > now() - "+string(argv[1]);
   if(argc == 3) {

--- a/tlecatch.cc
+++ b/tlecatch.cc
@@ -1,7 +1,21 @@
 #include "SGP4.h"
 #include <string>
 #include <time.h>
+#include "githash.h"
+#include "CLI/CLI.hpp"
+#include "version.hh"
+
+static char program[]="tlecatch";
+
 using namespace std;
+
+extern const char* g_gitHash;
+
+void showVersion()
+{
+    _showVersion(program,g_gitHash)
+}
+
 int main(int argc, char **argv)
 {
   string line;
@@ -9,7 +23,23 @@ int main(int argc, char **argv)
   time_t now = time(0);
   struct tm tm;
   gmtime_r(&now, &tm);
-    
+  bool doVERSION{false};
+
+  CLI::App app(program);
+
+  app.add_flag("--version", doVERSION, "show program version and copyright");
+
+  try {
+    app.parse(argc, argv);
+  } catch(const CLI::Error &e) {
+    return app.exit(e);
+  }
+
+  if(doVERSION) {
+    showVersion();
+    exit(0);
+  }
+
   for(;;) {
     DateTime d(1900 + tm.tm_year, tm.tm_mon+1, tm.tm_mday, 04, 43, 51);
     string name, line1, line2;

--- a/tlecatch.cc
+++ b/tlecatch.cc
@@ -11,11 +11,6 @@ using namespace std;
 
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 int main(int argc, char **argv)
 {
   string line;
@@ -36,7 +31,7 @@ int main(int argc, char **argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -50,11 +50,6 @@ int g_fixtype{-1};
 double g_speed{-1};
 extern const char* g_gitHash;
 
-void showVersion()
-{
-    _showVersion(program,g_gitHash)
-}
-
 static int getBaudrate(int baud)
 {
   if(baud==115200)
@@ -599,7 +594,7 @@ int main(int argc, char** argv)
   }
 
   if(doVERSION) {
-    showVersion();
+    showVersion(program, g_gitHash);
     exit(0);
   }
 

--- a/version.hh
+++ b/version.hh
@@ -1,8 +1,9 @@
 #pragma once
 
-#define _showVersion(program,g_gitHash) { \
-  cout <<"galmon tools (" <<program <<") " <<g_gitHash <<endl; \
-  cout <<"built date " <<__DATE__ <<endl; \
-  cout <<"(C) AHU Holding BV - bert@hubertnet.nl - https://berthub.eu/" <<endl; \
-  cout <<"https://galmon.eu/ - https://github.com/ahupowerdns/galmon" <<endl; \
-  cout <<"License GPLv3: GNU GPL version 3  https://gnu.org/licenses/gpl.html" <<endl; }
+void showVersion(char *pname, const char *hash) {
+  std::cout <<"galmon tools (" <<pname <<") " <<hash <<std::endl;
+  std::cout <<"built date " <<__DATE__ <<std::endl;
+  std::cout <<"(C) AHU Holding BV - bert@hubertnet.nl - https://berthub.eu/" <<std::endl;
+  std::cout <<"https://galmon.eu/ - https://github.com/ahupowerdns/galmon" <<std::endl;
+  std::cout <<"License GPLv3: GNU GPL version 3  https://gnu.org/licenses/gpl.html" <<std::endl;
+}

--- a/version.hh
+++ b/version.hh
@@ -1,0 +1,8 @@
+#pragma once
+
+#define _showVersion(program,g_gitHash) { \
+  cout <<"galmon tools (" <<program <<") " <<g_gitHash <<endl; \
+  cout <<"built date " <<__DATE__ <<endl; \
+  cout <<"(C) AHU Holding BV - bert@hubertnet.nl - https://berthub.eu/" <<endl; \
+  cout <<"https://galmon.eu/ - https://github.com/ahupowerdns/galmon" <<endl; \
+  cout <<"License GPLv3: GNU GPL version 3  https://gnu.org/licenses/gpl.html" <<endl; }


### PR DESCRIPTION
after chatting with ptudor on tasks associated with #91 I accidentally volunteered myself to add version info to all the executables.

First stab at a massive change; tried to at least follow the spirit of how things were being done.

I kept the actual "version" text as a separate header and macro so that the format could be easily updated without having to go through each individual file and potentially leave them out of sync.

The current version text is loosely based on https://www.gnu.org/prep/standards/html_node/_002d_002dversion.html  guidelines
