### PR TITLE
allow bare positional parameters when no other Opts are defined

### DIFF
--- a/galmonmon.cc
+++ b/galmonmon.cc
@@ -176,6 +176,7 @@ int main(int argc, char **argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 

--- a/navcat.cc
+++ b/navcat.cc
@@ -173,6 +173,7 @@ int main(int argc, char** argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 

--- a/navdisplay.cc
+++ b/navdisplay.cc
@@ -148,6 +148,7 @@ int main(int argc, char** argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 

--- a/navnexus.cc
+++ b/navnexus.cc
@@ -153,6 +153,7 @@ int main(int argc, char** argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 

--- a/navrecv.cc
+++ b/navrecv.cc
@@ -192,6 +192,7 @@ int main(int argc, char** argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 

--- a/tlecatch.cc
+++ b/tlecatch.cc
@@ -21,6 +21,7 @@ int main(int argc, char **argv)
   bool doVERSION{false};
 
   CLI::App app(program);
+  app.allow_extras(true); // allow bare positional parameters
 
   app.add_flag("--version", doVERSION, "show program version and copyright");
 


### PR DESCRIPTION
For apps that are still using positional parameters, this will allow them to function until such time as the parameters are converted into --opts and --flags.