### PR TITLE
QuickFix inability to enable exists ubxtool without error/warning

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -918,7 +918,7 @@ int main(int argc, char** argv)
           if (doDEBUG) { cerr<<humanTimeNow()<<" Got ack on SBAS setting"<<endl; }
         }
         else {
-          if (doDEBUG) { cerr<<humanTimeNow()<<" Got nack on SBAS setting"<<endl; }
+          cerr<<humanTimeNow()<<" Got nack on SBAS setting"<<endl;
           exit(-1);
         }
       }


### PR DESCRIPTION
Quick patch, after reading some tweets/IRC etc decided to enable SBAS. ubxtool kept dying all of a sudden. Turned out the error on the NACK on the ubxmessage to  enable SBAS is enclosed by an doDebug statement. Now it gives this:

Now it gives this:
```
root@alzira:~/Sources/galmon# ./ubxtool --gps --glonass --beidou --galileo --sbas --port /dev/ttyACM0 --station 89 --destination submit.galmon.eu --keep-nmea --owner SJC
Tue, 18 Feb 2020 19:02:42 +0000 swVersion: EXT CORE 1.00 (61b2dd)
Tue, 18 Feb 2020 19:02:42 +0000 hwVersion: 00190000
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: ROM BASE 0x118B2060
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: FWVER=HPG 1.12
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: PROTVER=27.11
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: MOD=ZED-F9P
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: GPS;GLO;GAL;BDS
Tue, 18 Feb 2020 19:02:42 +0000 Extended info: QZSS
Tue, 18 Feb 2020 19:02:42 +0000 Serial number 7e4d221698
Tue, 18 Feb 2020 19:02:42 +0000 Detected version U-Blox 9
Retransmit
Tue, 18 Feb 2020 19:02:42 +0000 Got nack on SBAS setting
```

Previously it would die after the retransmit, it felt like an transmission / connectivity issue instead.