### PR TITLE
Patch to suppress non-essential logging

### DIFF
--- a/ubxtool.cc
+++ b/ubxtool.cc
@@ -1046,7 +1046,7 @@ int main(int argc, char** argv)
   int curCycleTOW{-1}; // means invalid
   ns.launch();
   
-  if (!doSILENT) { cerr<<humanTimeNow()<<" Entering main loop"<<endl; }
+  cerr<<humanTimeNow()<<" Entering main loop"<<endl;
   for(;;) {
     try {
       auto [msg, timestamp] = getUBXMessage(fd, nullptr);


### PR DESCRIPTION
The current ubxtool, due to navparse is using stderr as general purpose logging. This makes it hard to differentiate in parsing between errors and normal logging. As well these are often writes on an SD card on a Raspberry. 

This patch removes most periodic logging with the command line "--silent"