### PR TITLE
Update dockerfile to use Ubuntu 19.10.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:disco
+FROM ubuntu:eoan
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8


### PR DESCRIPTION
Ubuntu 19.04 is no longer supported by Ubuntu, upgrade docker image to use Ubuntu 19.10.

I would have upgraded to Ubuntu 20.04 but I hit this bug (which caused the docker container to not run on hosts with linux 4.x):

https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1867675