### PR TITLE
Longstanding typo that caused incorrect tooltip display

### DIFF
--- a/html/geo/geo.js
+++ b/html/geo/geo.js
@@ -143,6 +143,9 @@ var Tooltip;
 
 function create_tooltop()
 {
+	if (Tooltip) {
+		return;
+	}
 	// create a tooltip
 	Tooltip = d3.select("#combined")
 		.append("span")


### PR DESCRIPTION
This is such an obvious error that's sat in the code for ages. Once fixed, the tooltip for satellites and observers displays correctly. duh!